### PR TITLE
Helm app chart init script

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -13,6 +13,22 @@ use_repo(bazel_lib_toolchains, "zstd_toolchains")
 bazel_dep(name = "rules_multirun", version = "0.10.0")
 
 ######################
+# Binary tools support
+######################
+bazel_dep(name = "rules_bin_tools")
+git_override(
+    module_name = "rules_bin_tools",
+    commit = "d3fefc59031fe28fcc41918f8e9df752c58c3c49",
+    remote = "https://github.com/ggramal/rules_bin_tools",
+)
+
+tools = use_extension("@rules_bin_tools//tools:extensions.bzl", "tools")
+tools.download(
+    helm_version = "v3.18.4",
+)
+use_repo(tools, "helm_executable")
+
+######################
 # Terraform support
 ######################
 

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -25,8 +25,9 @@ git_override(
 tools = use_extension("@rules_bin_tools//tools:extensions.bzl", "tools")
 tools.download(
     helm_version = "v3.18.4",
+    suffix = "exec",
 )
-use_repo(tools, "helm_executable")
+use_repo(tools, "helm_exec")
 
 ######################
 # Terraform support

--- a/libs/py/helpers/BUILD.bazel
+++ b/libs/py/helpers/BUILD.bazel
@@ -5,6 +5,6 @@ py_lint()
 
 py_library(
     name = "helpers",
-    srcs = ["__init__.py"],
+    srcs = glob(["*.py"])
     visibility = ["//visibility:public"],
 )

--- a/libs/py/helpers/BUILD.bazel
+++ b/libs/py/helpers/BUILD.bazel
@@ -5,6 +5,6 @@ py_lint()
 
 py_library(
     name = "helpers",
-    srcs = glob(["*.py"])
+    srcs = glob(["*.py"]),
     visibility = ["//visibility:public"],
 )

--- a/libs/py/helpers/__init__.py
+++ b/libs/py/helpers/__init__.py
@@ -41,6 +41,7 @@ def run_command(command, print_stdout=True, raise_exception=False):
     if result.returncode != 0:
         print("Command failed with return code:", result.returncode)
         if raise_exception:
+            print(123)
             raise CommandException(result.returncode, stdout)
 
     return result.returncode, stdout

--- a/libs/py/helpers/__init__.py
+++ b/libs/py/helpers/__init__.py
@@ -27,21 +27,28 @@ def unmask_tf(folder, mask_str=MASK_STR, unmask_str=UNMASK_STR):
             f.write(content)
 
 
-def run_command(command, print_stdout=True, raise_exception=False):
+def run_command(command, print_stdout=True, print_stderr=True, raise_exception=False):
     command_str = " ".join(command)
     stdout = []
+    stderr = []
     print(f"Running: {command_str}")
-    result = subprocess.Popen(command, stdout=subprocess.PIPE, text=True)
+    result = subprocess.Popen(
+        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+    )
     for line in result.stdout:
         stdout.append(line.strip())
         if print_stdout:
+            print(line, end="")
+
+    for line in result.stderr:
+        stderr.append(line.strip())
+        if print_stderr:
             print(line, end="")
 
     result.wait()
     if result.returncode != 0:
         print("Command failed with return code:", result.returncode)
         if raise_exception:
-            print(123)
-            raise CommandException(result.returncode, stdout)
+            raise CommandException(result.returncode, "\n".join(stderr))
 
-    return result.returncode, stdout
+    return result.returncode, stderr, stdout

--- a/libs/py/helpers/__init__.py
+++ b/libs/py/helpers/__init__.py
@@ -1,4 +1,4 @@
-from libs.py.helpers.exceptions import CommandException 
+from libs.py.helpers.exceptions import CommandException
 import subprocess
 import glob
 import re

--- a/libs/py/helpers/__init__.py
+++ b/libs/py/helpers/__init__.py
@@ -1,3 +1,4 @@
+from libs.py.helpers.exceptions import CommandException 
 import subprocess
 import glob
 import re
@@ -26,7 +27,7 @@ def unmask_tf(folder, mask_str=MASK_STR, unmask_str=UNMASK_STR):
             f.write(content)
 
 
-def run_command(command, print_stdout=True):
+def run_command(command, print_stdout=True, raise_exception=False):
     command_str = " ".join(command)
     stdout = []
     print(f"Running: {command_str}")
@@ -39,5 +40,7 @@ def run_command(command, print_stdout=True):
     result.wait()
     if result.returncode != 0:
         print("Command failed with return code:", result.returncode)
+        if raise_exception:
+            raise CommandException(result.returncode, stdout)
 
     return result.returncode, stdout

--- a/libs/py/helpers/exceptions.py
+++ b/libs/py/helpers/exceptions.py
@@ -1,0 +1,2 @@
+class CommandException(BaseException)
+    pass

--- a/libs/py/helpers/exceptions.py
+++ b/libs/py/helpers/exceptions.py
@@ -1,2 +1,2 @@
-class CommandException(BaseException)
+class CommandException(BaseException):
     pass

--- a/scripts/helm/apps/BUILD.bazel
+++ b/scripts/helm/apps/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@svetoch_bazel_lib//tools/lint/py:black.bzl", "py_lint")
+
+py_lint()
+
+filegroup(
+    name = "init_services",
+    srcs = ["init_services.py"],
+    visibility = ["//visibility:public"],
+)

--- a/scripts/helm/apps/BUILD.bazel
+++ b/scripts/helm/apps/BUILD.bazel
@@ -3,7 +3,7 @@ load("@svetoch_bazel_lib//tools/lint/py:black.bzl", "py_lint")
 py_lint()
 
 filegroup(
-    name = "init_services",
-    srcs = ["init_services.py"],
+    name = "init",
+    srcs = ["init.py"],
     visibility = ["//visibility:public"],
 )

--- a/scripts/helm/apps/apps.bzl
+++ b/scripts/helm/apps/apps.bzl
@@ -1,6 +1,7 @@
 """
 Helm macros
 """
+
 load("@aspect_rules_py//py:defs.bzl", "py_binary")
 load("@svetoch_bazel_lib_py_deps//:requirements.bzl", "requirement")
 
@@ -19,7 +20,7 @@ def helm_app_init():
         },
         deps = [
             "@svetoch_bazel_lib//libs/py/helpers",
-            requirement("click")
+            requirement("click"),
         ],
         visibility = ["//visibility:public"],
     )

--- a/scripts/helm/apps/apps.bzl
+++ b/scripts/helm/apps/apps.bzl
@@ -1,0 +1,25 @@
+"""
+Helm macros
+"""
+load("@aspect_rules_py//py:defs.bzl", "py_binary")
+load("@svetoch_bazel_lib_py_deps//:requirements.bzl", "requirement")
+
+def helm_app_init():
+    """
+    Init app helm charts
+    """
+    py_binary(
+        name = "init",
+        srcs = ["@svetoch_bazel_lib//scripts/helm/apps/init_services"],
+        data = [
+            "@helm_executable//:executable",
+        ],
+        env = {
+            "HELM_EXECUTABLE": "$(rootpath @helm_executable//:executable)",
+        },
+        deps = [
+            "@svetoch_bazel_lib//libs/py/helpers",
+            requirement("click")
+        ],
+        visibility = ["//visibility:public"],
+    )

--- a/scripts/helm/apps/apps.bzl
+++ b/scripts/helm/apps/apps.bzl
@@ -21,6 +21,7 @@ def helm_app_init():
         deps = [
             "@svetoch_bazel_lib//libs/py/helpers",
             requirement("click"),
+            requirement("GitPython"),
         ],
         visibility = ["//visibility:public"],
     )

--- a/scripts/helm/apps/apps.bzl
+++ b/scripts/helm/apps/apps.bzl
@@ -10,7 +10,7 @@ def helm_app_init():
     """
     py_binary(
         name = "init",
-        srcs = ["@svetoch_bazel_lib//scripts/helm/apps/init_services"],
+        srcs = ["@svetoch_bazel_lib//scripts/helm/apps:init"],
         data = [
             "@helm_executable//:executable",
         ],

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -1,21 +1,17 @@
 from git import Repo
 from libs.py.helpers import run_command
+from libs.py.helpers.exceptions import CommandException
 import os
+import sys
 import click
 
 REPO_PATH = os.environ["BUILD_WORKSPACE_DIRECTORY"]
 HELM_EXECUTABLE = os.environ["HELM_EXECUTABLE"]
 APP_CHART_PATH_DEFAULT = f"{REPO_PATH}/argocd/charts/app"
 
-
 def init_submodules(repo):
     """Initialize and update submodules."""
     repo.submodule_update(init=True, recursive=True)
-
-
-def helm_app_init(chart_path):
-    run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
-
 
 @click.command()
 @click.argument("app_name", required=True, type=click.STRING)
@@ -25,7 +21,18 @@ def main(app_name, app_chart_path):
 
     init_submodules(repo)
 
-    print(f"{app_chart_path}/{app_name}")
+    chart_path = f"{app_chart_path}/{app_name}"
+
+    if os.path.exists(chart_path):
+        try:
+            #run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
+            run_command("hui",raise_exception=True)
+        except CommandException as e:
+            dir(e)
+            sys.exit(1)
+    else:
+        print("Path does not exist")
+        sys.exit(1)
 
     print("success")
 

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -25,7 +25,7 @@ def main(app_name, app_chart_path):
 
     init_submodules(repo)
 
-    print(f"{app_chart_path}/{app_nam}")
+    print(f"{app_chart_path}/{app_name}")
 
     print("success")
 

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -28,7 +28,7 @@ def main(app_name, app_chart_path):
     if os.path.exists(chart_path):
         try:
             run_command(
-                [HELM_EXECUTABLE, "dependency", "update", "hui"], raise_exception=True
+                [HELM_EXECUTABLE, "dependency", "update", chart_path], raise_exception=True
             )
         except CommandException as e:
             sys.exit(e.args[0])

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -29,6 +29,7 @@ def main(app_name, app_chart_path):
         try:
             run_command([HELM_EXECUTABLE, "dependency", "update", "hui"], raise_exception=True)
         except CommandException as e:
+            print(321)
             dir(e)
             sys.exit(1)
     else:

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -27,11 +27,11 @@ def main(app_name, app_chart_path):
 
     if os.path.exists(chart_path):
         try:
-            run_command([HELM_EXECUTABLE, "dependency", "update", "hui"], raise_exception=True)
+            run_command(
+                [HELM_EXECUTABLE, "dependency", "update", "hui"], raise_exception=True
+            )
         except CommandException as e:
-            print(321)
-            dir(e)
-            sys.exit(1)
+            sys.exit(e.args[0])
     else:
         print("Path does not exist")
         sys.exit(1)

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -6,11 +6,13 @@ REPO_PATH = os.environ["BUILD_WORKSPACE_DIRECTORY"]
 HELM_EXECUTABLE = os.environ["HELM_EXECUTABLE"]
 APP_CHART_PATH_DEFAULT = f"{REPO_PATH}/argocd/charts/app"
 
+
 def init_submodules(repo):
     """Initialize and update submodules."""
     repo.submodule_update(init=True, recursive=True)
 
-def helm_app_init(chart_path)
+
+def helm_app_init(chart_path):
     run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
 
 
@@ -25,6 +27,7 @@ def main(app_name, app_chart_path):
     print(f"{app_chart_path}/{app_nam}")
 
     print("success")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -1,0 +1,30 @@
+from git import Repo
+from libs.py.helpers import run_command
+import os
+
+REPO_PATH = os.environ["BUILD_WORKSPACE_DIRECTORY"]
+HELM_EXECUTABLE = os.environ["HELM_EXECUTABLE"]
+APP_CHART_PATH_DEFAULT = f"{REPO_PATH}/argocd/charts/app"
+
+def init_submodules(repo):
+    """Initialize and update submodules."""
+    repo.submodule_update(init=True, recursive=True)
+
+def helm_app_init(chart_path)
+    run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
+
+
+@click.command()
+@click.argument("app_name", required=True, type=click.STRING)
+@click.option("--app_chart_path", default=APP_CHART_PATH_DEFAULT, required=False)
+def main(app_name, app_chart_path):
+    repo = Repo(REPO_PATH)
+
+    init_submodules(repo)
+
+    print(f"{app_chart_path}/{app_nam}")
+
+    print("success")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -1,6 +1,7 @@
 from git import Repo
 from libs.py.helpers import run_command
 import os
+import click
 
 REPO_PATH = os.environ["BUILD_WORKSPACE_DIRECTORY"]
 HELM_EXECUTABLE = os.environ["HELM_EXECUTABLE"]

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -9,9 +9,11 @@ REPO_PATH = os.environ["BUILD_WORKSPACE_DIRECTORY"]
 HELM_EXECUTABLE = os.environ["HELM_EXECUTABLE"]
 APP_CHART_PATH_DEFAULT = f"{REPO_PATH}/argocd/charts/app"
 
+
 def init_submodules(repo):
     """Initialize and update submodules."""
     repo.submodule_update(init=True, recursive=True)
+
 
 @click.command()
 @click.argument("app_name", required=True, type=click.STRING)
@@ -25,8 +27,8 @@ def main(app_name, app_chart_path):
 
     if os.path.exists(chart_path):
         try:
-            #run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
-            run_command("hui",raise_exception=True)
+            # run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
+            run_command("hui", raise_exception=True)
         except CommandException as e:
             dir(e)
             sys.exit(1)

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -23,21 +23,31 @@ def main(app_name, app_chart_path):
 
     init_submodules(repo)
 
-    chart_path = f"{app_chart_path}/{app_name}"
+    if os.path.exists(app_chart_path):
+        charts = []
+        failure_count = 0
+        if app_name == "all":
+            for file_name in os.listdir(app_chart_path):
+                file_name = f"{app_chart_path}/{file_name}"
+                if os.path.isdir(file_name):
+                    charts.append(file_name)
+        else:
+            charts.append(f"{app_chart_path}/{app_name}")
 
-    if os.path.exists(chart_path):
-        try:
-            run_command(
-                [HELM_EXECUTABLE, "dependency", "update", chart_path],
-                raise_exception=True,
-            )
-        except CommandException as e:
-            sys.exit(e.args[0])
+        for chart in charts:
+            try:
+                run_command(
+                    [HELM_EXECUTABLE, "dependency", "update", chart],
+                    raise_exception=True,
+                )
+            except CommandException as e:
+                failure_count += 1
+
+        if failure_count > 0:
+            sys.exit(1)
     else:
-        print("Path does not exist")
+        print(f"{app_chart_path} path does not exist")
         sys.exit(1)
-
-    print("success")
 
 
 if __name__ == "__main__":

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -28,7 +28,8 @@ def main(app_name, app_chart_path):
     if os.path.exists(chart_path):
         try:
             run_command(
-                [HELM_EXECUTABLE, "dependency", "update", chart_path], raise_exception=True
+                [HELM_EXECUTABLE, "dependency", "update", chart_path],
+                raise_exception=True,
             )
         except CommandException as e:
             sys.exit(e.args[0])

--- a/scripts/helm/apps/init.py
+++ b/scripts/helm/apps/init.py
@@ -27,8 +27,7 @@ def main(app_name, app_chart_path):
 
     if os.path.exists(chart_path):
         try:
-            # run_command([HELM_EXECUTABLE, "dependency", "update", chart_path])
-            run_command("hui", raise_exception=True)
+            run_command([HELM_EXECUTABLE, "dependency", "update", "hui"], raise_exception=True)
         except CommandException as e:
             dir(e)
             sys.exit(1)

--- a/scripts/init/tf/apply/apply.py
+++ b/scripts/init/tf/apply/apply.py
@@ -40,7 +40,7 @@ def apply(targets):
     os.chdir(WORKSPACE_FOLDER)
     target_objs = []
     query = ["bazel", "query", 'attr(name, "^apply$|^gh_apply$", "//terraform/...")']
-    return_code, apply_targets = run_command(query, print_stdout=False)
+    return_code, stderr, apply_targets = run_command(query, print_stdout=False)
     for target, is_masked in targets:
         if target in apply_targets:
             target_objs.append(Target(target, is_masked))

--- a/scripts/init/tf/secrets/secrets.py
+++ b/scripts/init/tf/secrets/secrets.py
@@ -30,9 +30,7 @@ def secrets(secrets):
 
         state_list_command = ["bazel", "run", ":tf", "state", "list"]
         exit_code, stderr, tf_resources = run_command(
-            state_list_command,
-            print_stdout=False,
-            print_stderr=False
+            state_list_command, print_stdout=False, print_stderr=False
         )
 
         for secret_key in secret_keys.split(","):

--- a/scripts/init/tf/secrets/secrets.py
+++ b/scripts/init/tf/secrets/secrets.py
@@ -30,8 +30,9 @@ def secrets(secrets):
 
         state_list_command = ["bazel", "run", ":tf", "state", "list"]
         exit_code, stderr, tf_resources = run_command(
-            state_list_command, print_stdout=False, print_stderr=False
+            state_list_command, print_stdout=False
         )
+
 
         for secret_key in secret_keys.split(","):
             tf_resource = f'module.secrets["{secret_name}"].module.import_secret["{secret_key}"].secret_resource.secret'
@@ -45,17 +46,17 @@ def secrets(secrets):
                 try:
                     secret_value = os.environ[env_var_name]
                     import_command.append(secret_value)
-                    run_command(import_command, print_stderr=False)
+                    run_command(import_command)
                 except KeyError as e:
                     print(f"{env_var_name} is not set using prompt")
                     secret_value = input(f"Enter secret for {tf_resource}: ")
                     import_command.append(secret_value)
-                    run_command(import_command, print_stderr=False)
+                    run_command(import_command)
 
     for secret_state in secret_states:
         os.chdir(secret_state)
         command = ["bazel", "run", ":apply"]
-        run_command(command, print_stderr=False)
+        run_command(command)
 
 
 if __name__ == "__main__":

--- a/scripts/init/tf/secrets/secrets.py
+++ b/scripts/init/tf/secrets/secrets.py
@@ -30,7 +30,9 @@ def secrets(secrets):
 
         state_list_command = ["bazel", "run", ":tf", "state", "list"]
         exit_code, stderr, tf_resources = run_command(
-            state_list_command, print_stdout=False
+            state_list_command,
+            print_stdout=False,
+            print_stderr=False
         )
 
         for secret_key in secret_keys.split(","):
@@ -45,17 +47,17 @@ def secrets(secrets):
                 try:
                     secret_value = os.environ[env_var_name]
                     import_command.append(secret_value)
-                    run_command(import_command)
+                    run_command(import_command, print_stderr=False)
                 except KeyError as e:
                     print(f"{env_var_name} is not set using prompt")
                     secret_value = input(f"Enter secret for {tf_resource}: ")
                     import_command.append(secret_value)
-                    run_command(import_command)
+                    run_command(import_command, print_stderr=False)
 
     for secret_state in secret_states:
         os.chdir(secret_state)
         command = ["bazel", "run", ":apply"]
-        run_command(command)
+        run_command(command, print_stderr=False)
 
 
 if __name__ == "__main__":

--- a/scripts/init/tf/secrets/secrets.py
+++ b/scripts/init/tf/secrets/secrets.py
@@ -29,7 +29,9 @@ def secrets(secrets):
             secret_states.append(state_path)
 
         state_list_command = ["bazel", "run", ":tf", "state", "list"]
-        exit_code, tf_resources = run_command(state_list_command, print_stdout=False)
+        exit_code, stderr, tf_resources = run_command(
+            state_list_command, print_stdout=False
+        )
 
         for secret_key in secret_keys.split(","):
             tf_resource = f'module.secrets["{secret_name}"].module.import_secret["{secret_key}"].secret_resource.secret'

--- a/tools/lint/fix_all.py
+++ b/tools/lint/fix_all.py
@@ -19,10 +19,12 @@ def main():
         "query",
         'attr(name, "^(lint_fix_py|lint_fix_tf|lint_fix_bzl)$", "//...")',
     ]
-    return_code, output = run_command(command, print_stdout=False)
+    return_code, stderr, output = run_command(
+        command, print_stdout=False, print_stderr=False
+    )
     for target in output:
         command = ["bazel", "run", target]
-        run_command(command)
+        run_command(command, print_stderr=False)
 
 
 if __name__ == "__main__":

--- a/tools/lint/py/BUILD.bazel
+++ b/tools/lint/py/BUILD.bazel
@@ -1,5 +1,5 @@
 filegroup(
-    name = "black_src",
+    name = "black",
     srcs = ["black.py"],
     visibility = ["//visibility:public"],
 )

--- a/tools/lint/py/black.bzl
+++ b/tools/lint/py/black.bzl
@@ -11,7 +11,7 @@ def py_lint():
     """
     py_test(
         name = "lint",
-        srcs = ["@svetoch_bazel_lib//tools/lint/py:black_src"],
+        srcs = ["@svetoch_bazel_lib//tools/lint/py:black"],
         data = native.glob(["**/*.py"]),
         args = [
             #All *.py files in WORKSPACE
@@ -35,7 +35,7 @@ def py_lint_fix():
 
     py_binary(
         name = "lint_fix_py",
-        srcs = ["@svetoch_bazel_lib//tools/lint/py:black_src"],
+        srcs = ["@svetoch_bazel_lib//tools/lint/py:black"],
         main = "black.py",
         args = [
             #Fix all *.py files in WORKSPACE


### PR DESCRIPTION
Features:
* `scripts/helm/apps:init` : script for new services initialization of an app.
```
Usage:
  `bazel run //scripts/helm/apps:init --  '<chart name>' --app_chart_path '<app chart path>'

Where
* `<chart name>` - chart name in app dir or `all`. When `all` is used all charts are being initialized
* `<app chart path>` - path to folder where charts are being stored DEFAULT:  argocd/charts/app

Examples:
bazel run  //scripts/helm/apps:init somechart
bazel run //scripts/helm/apps:init all
bazel run //scripts/helm/apps:init -- somechart2 --app_chart_path /some/other/path
```
* `from libs.py.helpers import run_command`: support for stderr  