### PR TITLE
Change tfvars schema

### DIFF
--- a/.codex/rules/bazel.rules
+++ b/.codex/rules/bazel.rules
@@ -1,0 +1,5 @@
+prefix_rule(
+    pattern = ["bazel", ["test", "build"]],
+    decision = "allow",
+    justification = "Allow bazel test",
+)

--- a/.codex/rules/git.rules
+++ b/.codex/rules/git.rules
@@ -1,0 +1,12 @@
+prefix_rule(
+    pattern = ["git", ["status", "diff", "log", "show", "branch", "rev-parse", "remote", "ls-files", "ls-remote"]],
+    decision = "allow",
+    justification = "Allow safe read-only git inspection commands.",
+    match = [
+        "git status",
+        "git diff",
+        "git log --oneline -20",
+        "git show HEAD",
+        "git branch --show-current",
+    ],
+)

--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,3 @@ MODULE.bazel.lock
 
 ## Python ##
 venv
-
-## Codex ##
-.codex

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# v0.17.0
+
+## ⚠️ Breaking Changes:
+
+### terrafrom.tfvars.json schema changes
+
+* `env.cloud.registry` is moved to `env.registry` and type is changed to object
+* `env.dns` new mandatory object variable
+* `env.cloud.{region,default_zone,multi_region}` attributes are moved under `env.cloud.location`
+
+
+Features:
+* `terrafrom.tfvars.json` variables validation
+
 # v0.16.0
 
 ## ⚠️ Breaking Changes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 Features:
 * `terrafrom.tfvars.json` variables validation
+* `.codex/rules/bazel.rules` codex rules that allow `bazel {build,test} *` commands
 
 # v0.16.0
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,124 @@
+# v0.17.0
+
+This release changes the `terraform.tfvars.json` schema consumed by
+`svetoch_bazel_lib`. Agents upgrading a downstream project should edit the
+project's root `terraform.tfvars.json` and any generated examples, tests, or
+documentation that duplicate that schema.
+
+## Agent Upgrade Checklist
+
+1. Update the `svetoch_bazel_lib` `git_override` commit in `MODULE.bazel` to
+   the commit which target release git tag is pointing to.
+2. Open the downstream project's `terraform.tfvars.json`.
+3. For every object under `envs`, migrate the environment schema:
+   - Move `cloud.region`, `cloud.default_zone`, and `cloud.multi_region` into
+     `cloud.location`.
+   - Move `cloud.registry` out of `cloud` and replace it with top-level
+     environment object `registry`.
+   - Add top-level environment object `dns`.
+4. Replace old placeholder paths in tfvars strings and templates:
+   - Use `{env.cloud.location.region}` instead of `{env.cloud.region}`.
+   - Use `{env.registry.url}` instead of `{env.cloud.registry}` when a registry
+     URL is needed.
+   - Use `{env.dns.domain}` or `{env.dns.type}` when DNS data is needed.
+5. Normalize enum-like values to the new allowed strings:
+   - `ci.type`: `gl` or `gha`.
+   - `repo.type`: `gitlab` or `github`.
+   - `envs[*].cloud.name`: `gcp` or `yc`.
+   - `envs[*].dns.type`: `gcp` or `yc`.
+   - `envs[*].registry.type`: `gar` or `ycr`.
+6. If `envs[*].cloud.name` is `yc`, ensure `envs[*].cloud.folder_id` is set to
+   a non-empty string.
+7. Run `bazel test //...` from the downstream repository root. If that is too
+   broad for the context, run at least the init/Terraform-related test targets
+   and the targets that read `terraform.tfvars.json`.
+
+## terraform.tfvars.json Migration
+
+Old shape:
+
+```json
+{
+  "envs": {
+    "production": {
+      "cloud": {
+        "name": "gcp",
+        "id": "example-production",
+        "region": "europe-west2",
+        "default_zone": "europe-west2-c",
+        "multi_region": "EU",
+        "registry": "{env.cloud.region}-docker.pkg.dev/{env.cloud.id}/containers"
+      }
+    }
+  }
+}
+```
+
+New shape:
+
+```json
+{
+  "envs": {
+    "production": {
+      "registry": {
+        "type": "gar",
+        "url": "{env.cloud.location.region}-docker.pkg.dev/{env.cloud.id}/containers"
+      },
+      "dns": {
+        "domain": "{env.short_name}.{company.domain}",
+        "type": "gcp"
+      },
+      "cloud": {
+        "name": "gcp",
+        "id": "example-production",
+        "location": {
+          "region": "europe-west2",
+          "default_zone": "europe-west2-c",
+          "multi_region": "EU"
+        }
+      }
+    }
+  }
+}
+```
+
+For Yandex Cloud environments, use this pattern:
+
+```json
+{
+  "registry": {
+    "type": "ycr",
+    "url": "cr.yandex/<registry-id>"
+  },
+  "dns": {
+    "domain": "{env.short_name}.{company.domain}",
+    "type": "yc"
+  },
+  "cloud": {
+    "name": "yc",
+    "id": "<cloud-id>",
+    "folder_id": "<folder-id>",
+    "location": {
+      "region": "ru-central1",
+      "default_zone": "ru-central1-a"
+    }
+  }
+}
+```
+
+## Common Agent Pitfalls
+
+- Do not leave `registry` inside `cloud`; consumers now read
+  `env.registry.url`.
+- Do not leave location fields directly under `cloud`; consumers now read
+  `env.cloud.location.region`.
+- Do not use provider names interchangeably: `repo.type` is `github` or
+  `gitlab`, while `ci.type` is `gha` or `gl`.
+- Do not omit `dns`; it is now required for each environment.
+- Do not use `yc` as a registry type. Use `ycr` for Yandex Container Registry.
+- For `yc` cloud environments, do not rely on `cloud.id` alone; set
+  `cloud.folder_id`.
+
 # v0.16.0
 
 Update `git_override` commit for `svetoch_bazel_lib` to commit that `v0.16.0` tag points to eg

--- a/rod/libs/py/tf/test_tfvars.py
+++ b/rod/libs/py/tf/test_tfvars.py
@@ -4,6 +4,7 @@ from rod.libs.py.tf.tfvars import (
     formatted_tfvars,
     TfVars,
     Ci,
+    Repo,
     tfvars,
     Env,
     App,
@@ -105,3 +106,96 @@ class TestFormattedTfvars(unittest.TestCase):
     def test_ci_type_rejects_unsupported_values(self):
         with self.assertRaises(ValidationError):
             Ci(type="gitlab", group="test")
+
+    def test_repo_type_accepts_supported_values(self):
+        self.assertEqual(Repo(name="test", type="github", group="test").type, "github")
+        self.assertEqual(Repo(name="test", type="gitlab", group="test").type, "gitlab")
+
+    def test_repo_type_rejects_unsupported_values(self):
+        with self.assertRaises(ValidationError):
+            Repo(name="test", type="gha", group="test")
+
+    def test_cloud_name_accepts_supported_values(self):
+        cloud = {
+            "id": "test",
+            "location": {
+                "region": "europe-west2",
+                "default_zone": "europe-west2-a",
+            },
+            "network": {
+                "vm_cidr": "10.8.0.0/20",
+                "k8s_pod_cidr": "10.12.0.0/14",
+                "k8s_service_cidr": "10.9.0.0/20",
+            },
+            "buckets": {"multi_regional": True},
+        }
+
+        self.assertEqual(Cloud(name="gcp", **cloud).name, "gcp")
+        self.assertEqual(Cloud(name="yc", folder_id="yc-folder", **cloud).name, "yc")
+
+    def test_cloud_name_rejects_unsupported_values(self):
+        with self.assertRaises(ValidationError):
+            Cloud(
+                name="none_existant_cloud",
+                id="test",
+                location={
+                    "region": "europe-west2",
+                    "default_zone": "europe-west2-a",
+                },
+                network={
+                    "vm_cidr": "10.8.0.0/20",
+                    "k8s_pod_cidr": "10.12.0.0/14",
+                    "k8s_service_cidr": "10.9.0.0/20",
+                },
+                buckets={"multi_regional": True},
+            )
+
+    def test_yc_cloud_requires_folder_id(self):
+        with self.assertRaises(ValidationError):
+            Cloud(
+                name="yc",
+                id="test",
+                location={
+                    "region": "ru-central1",
+                    "default_zone": "ru-central1-a",
+                },
+                network={
+                    "vm_cidr": "10.8.0.0/20",
+                    "k8s_pod_cidr": "10.12.0.0/14",
+                    "k8s_service_cidr": "10.9.0.0/20",
+                },
+                buckets={"multi_regional": False},
+            )
+
+        with self.assertRaises(ValidationError):
+            Cloud(
+                name="yc",
+                id="test",
+                folder_id="",
+                location={
+                    "region": "ru-central1",
+                    "default_zone": "ru-central1-a",
+                },
+                network={
+                    "vm_cidr": "10.8.0.0/20",
+                    "k8s_pod_cidr": "10.12.0.0/14",
+                    "k8s_service_cidr": "10.9.0.0/20",
+                },
+                buckets={"multi_regional": False},
+            )
+
+    def test_dns_type_accepts_supported_values(self):
+        self.assertEqual(Dns(domain="example.com", type="gcp").type, "gcp")
+        self.assertEqual(Dns(domain="example.com", type="yc").type, "yc")
+
+    def test_dns_type_rejects_unsupported_values(self):
+        with self.assertRaises(ValidationError):
+            Dns(domain="example.com", type="none_existant_domain")
+
+    def test_registry_type_accepts_supported_values(self):
+        self.assertEqual(Registry(type="ycr", url="registry.example.com").type, "ycr")
+        self.assertEqual(Registry(type="gar", url="registry.example.com").type, "gar")
+
+    def test_registry_type_rejects_unsupported_values(self):
+        with self.assertRaises(ValidationError):
+            Registry(type="none_existant_registry", url="registry.example.com")

--- a/rod/libs/py/tf/test_tfvars.py
+++ b/rod/libs/py/tf/test_tfvars.py
@@ -1,13 +1,18 @@
 import unittest
+from pydantic import ValidationError
 from rod.libs.py.tf.tfvars import (
     formatted_tfvars,
     TfVars,
+    Ci,
     tfvars,
     Env,
     App,
     AppAccessRoles,
     TfBackend,
+    Registry,
+    Dns,
     Cloud,
+    Location,
     Kubernetes,
 )
 
@@ -39,8 +44,14 @@ class TestFormattedTfvars(unittest.TestCase):
             "production/{tf_backend.state_name}",
         )
         self.assertEqual(prd.cloud.id, "rod-production")
+        self.assertEqual(prd.cloud.location.region, "europe-west2")
+        self.assertEqual(prd.cloud.location.default_zone, "europe-west2-c")
+        self.assertEqual(prd.cloud.location.multi_region, "EU")
+        self.assertEqual(prd.dns.domain, "prd.rod.svetoch.dev")
+        self.assertEqual(prd.dns.type, "gcp")
+        self.assertEqual(prd.registry.type, "gar")
         self.assertEqual(
-            prd.cloud.registry, "europe-west2-docker.pkg.dev/rod-production/containers"
+            prd.registry.url, "europe-west2-docker.pkg.dev/rod-production/containers"
         )
 
     def test_formatted_tfvars_formats_each_env_with_its_own_env_values(self):
@@ -59,12 +70,14 @@ class TestFormattedTfvars(unittest.TestCase):
 
         self.assertEqual(dev.cloud.id, "rod-development")
         self.assertEqual(prd.cloud.id, "rod-production")
+        self.assertEqual(dev.cloud.location.default_zone, "europe-west2-a")
+        self.assertEqual(prd.cloud.location.default_zone, "europe-west2-c")
 
         self.assertEqual(
-            prd.cloud.registry, "europe-west2-docker.pkg.dev/rod-production/containers"
+            prd.registry.url, "europe-west2-docker.pkg.dev/rod-production/containers"
         )
         self.assertEqual(
-            dev.cloud.registry, "europe-west2-docker.pkg.dev/rod-development/containers"
+            dev.registry.url, "europe-west2-docker.pkg.dev/rod-development/containers"
         )
 
     def test_formatted_tfvars_returns_validated_models(self):
@@ -73,7 +86,10 @@ class TestFormattedTfvars(unittest.TestCase):
 
         self.assertIsInstance(result, TfVars)
         self.assertIsInstance(result.envs["production"], Env)
+        self.assertIsInstance(result.envs["production"].registry, Registry)
+        self.assertIsInstance(result.envs["production"].dns, Dns)
         self.assertIsInstance(result.envs["production"].cloud, Cloud)
+        self.assertIsInstance(result.envs["production"].cloud.location, Location)
         self.assertIsInstance(result.envs["production"].tf_backend, TfBackend)
         self.assertIsInstance(result.envs["production"].kubernetes, Kubernetes)
         self.assertIsInstance(result.envs["production"].apps["example"], App)
@@ -81,3 +97,11 @@ class TestFormattedTfvars(unittest.TestCase):
             result.envs["production"].apps["example"].access_roles,
             AppAccessRoles,
         )
+
+    def test_ci_type_accepts_supported_values(self):
+        self.assertEqual(Ci(type="gl", group="test").type, "gl")
+        self.assertEqual(Ci(type="gha", group="test").type, "gha")
+
+    def test_ci_type_rejects_unsupported_values(self):
+        with self.assertRaises(ValidationError):
+            Ci(type="gitlab", group="test")

--- a/rod/libs/py/tf/tfvars.py
+++ b/rod/libs/py/tf/tfvars.py
@@ -1,3 +1,5 @@
+from typing import Literal
+
 from rod.libs.py.settings import bazel_settings
 from pydantic import BaseModel, ConfigDict
 from rod.libs.py.helpers import dict_to_dot_notation, replace_dotted_placeholders
@@ -38,9 +40,25 @@ class TfBackend(BaseTfVarsModel):
     configs: dict[str, str]
 
 
+class Registry(BaseTfVarsModel):
+    type: str
+    url: str
+
+
+class Dns(BaseTfVarsModel):
+    domain: str
+    type: str
+
+
 class Buckets(BaseTfVarsModel):
     multi_regional: bool
     deletion_protection: bool = True
+
+
+class Location(BaseTfVarsModel):
+    region: str
+    default_zone: str
+    multi_region: str = ""
 
 
 class Network(BaseTfVarsModel):
@@ -61,10 +79,7 @@ class Cloud(BaseTfVarsModel):
     name: str
     id: str
     folder_id: str | None = None
-    region: str
-    default_zone: str
-    multi_region: str
-    registry: str
+    location: Location
     network: Network
     buckets: Buckets
 
@@ -76,6 +91,8 @@ class Env(BaseTfVarsModel):
     users: dict[str, User]
     apps: dict[str, App]
     import_secrets: dict[str, ImportSecret]
+    registry: Registry
+    dns: Dns
     tf_backend: TfBackend
     cloud: Cloud
     kubernetes: Kubernetes
@@ -93,7 +110,7 @@ class Repo(BaseTfVarsModel):
 
 
 class Ci(BaseTfVarsModel):
-    type: str
+    type: Literal["gl", "gha"]
     group: str
     bazelisk_img_version: str = ""
 

--- a/rod/libs/py/tf/tfvars.py
+++ b/rod/libs/py/tf/tfvars.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from rod.libs.py.settings import bazel_settings
-from pydantic import BaseModel, ConfigDict
+from pydantic import BaseModel, ConfigDict, model_validator
 from rod.libs.py.helpers import dict_to_dot_notation, replace_dotted_placeholders
 
 
@@ -41,13 +41,13 @@ class TfBackend(BaseTfVarsModel):
 
 
 class Registry(BaseTfVarsModel):
-    type: str
+    type: Literal["ycr", "gar"]
     url: str
 
 
 class Dns(BaseTfVarsModel):
     domain: str
-    type: str
+    type: Literal["gcp", "yc"]
 
 
 class Buckets(BaseTfVarsModel):
@@ -76,12 +76,19 @@ class App(BaseTfVarsModel):
 
 
 class Cloud(BaseTfVarsModel):
-    name: str
+    name: Literal["gcp", "yc"]
     id: str
     folder_id: str | None = None
     location: Location
     network: Network
     buckets: Buckets
+
+    @model_validator(mode="after")
+    def validate_folder_id_for_yc(self):
+        if self.name == "yc" and not self.folder_id:
+            raise ValueError("folder_id must be set when cloud.name is yc")
+
+        return self
 
 
 class Env(BaseTfVarsModel):
@@ -105,7 +112,7 @@ class Company(BaseTfVarsModel):
 
 class Repo(BaseTfVarsModel):
     name: str
-    type: str
+    type: Literal["github", "gitlab"]
     group: str
 
 

--- a/rod/scripts/init/images/prepare/prepare.py
+++ b/rod/scripts/init/images/prepare/prepare.py
@@ -23,18 +23,18 @@ def create_cred_helpers():
 
     registries = []
 
-    for env_name, env_obj in tfvars.envs.items():
+    for env_obj in tfvars.envs.values():
 
-        if env_obj.cloud.name == "gcp":
+        if env_obj.registry.type == "gar":
             creds_helper = "gcloud"
-        elif env_obj.cloud.name == "yc":
+        elif env_obj.registry.type == "yc":
             creds_helper = "yc"
         else:
             raise CredsHelperNotImplemented(
-                f"creds_helper not found for this registry {env_obj.cloud.registry}"
+                f"creds_helper not found for this registry {env_obj.registry.url}"
             )
 
-        registries.append({"url": env_obj.cloud.registry, "creds_helper": creds_helper})
+        registries.append({"url": env_obj.registry.url, "creds_helper": creds_helper})
 
     configs = {"auths": {}, "credHelpers": {}}
 

--- a/rod/scripts/init/images/prepare/prepare.py
+++ b/rod/scripts/init/images/prepare/prepare.py
@@ -27,7 +27,7 @@ def create_cred_helpers():
 
         if env_obj.registry.type == "gar":
             creds_helper = "gcloud"
-        elif env_obj.registry.type == "yc":
+        elif env_obj.registry.type == "ycr":
             creds_helper = "yc"
         else:
             raise CredsHelperNotImplemented(

--- a/rod/scripts/init/tf/apply/tests.py
+++ b/rod/scripts/init/tf/apply/tests.py
@@ -6,7 +6,7 @@ from rod.scripts.init.tf.apply.apply import apply
 from rod.libs.py.tf.tfvars import Cloud, Env, TfVars
 
 cloud = Cloud(
-    name="<replace-me>",
+    name="yc",
     id="<replace-me>",
     folder_id="adadadadad",
     location={
@@ -29,16 +29,16 @@ env = Env(
     apps={},
     initial_start=True,
     import_secrets={},
-    registry={"type": "gar", "url": "registry"},
-    dns={"domain": "example.com", "type": "cloud-dns"},
-    tf_backend={"type": "gcs", "configs": {"bucket": "some-tf-state"}},
+    registry={"type": "ycr", "url": "registry"},
+    dns={"domain": "example.com", "type": "yc"},
+    tf_backend={"type": "s3", "configs": {"bucket": "some-tf-state"}},
     cloud=cloud,
     kubernetes={"enabled": False},
 )
 
 tfvars = TfVars(
     company={"name": "test", "domain": "test.com"},
-    repo={"type": "gha", "group": "test", "name": "test"},
+    repo={"type": "github", "group": "test", "name": "test"},
     ci={
         "type": "gha",
         "group": "test",

--- a/rod/scripts/init/tf/apply/tests.py
+++ b/rod/scripts/init/tf/apply/tests.py
@@ -9,15 +9,16 @@ cloud = Cloud(
     name="<replace-me>",
     id="<replace-me>",
     folder_id="adadadadad",
-    region="ignored",
-    default_zone="",
-    multi_region="",
+    location={
+        "region": "ignored",
+        "default_zone": "",
+        "multi_region": "",
+    },
     network={
         "vm_cidr": "10.8.0.0/20",
         "k8s_pod_cidr": "10.12.0.0/14",
         "k8s_service_cidr": "10.9.0.0/20",
     },
-    registry="registry",
     buckets={"multi_regional": "false"},
 )
 
@@ -28,6 +29,8 @@ env = Env(
     apps={},
     initial_start=True,
     import_secrets={},
+    registry={"type": "gar", "url": "registry"},
+    dns={"domain": "example.com", "type": "cloud-dns"},
     tf_backend={"type": "gcs", "configs": {"bucket": "some-tf-state"}},
     cloud=cloud,
     kubernetes={"enabled": False},

--- a/rod/scripts/init/tf/prepare/tests.py
+++ b/rod/scripts/init/tf/prepare/tests.py
@@ -8,7 +8,7 @@ from rod.scripts.init.tf.prepare.copy import copy_template
 from rod.libs.py.tf.tfvars import Cloud, Env
 
 cloud = Cloud(
-    name="<replace-me>",
+    name="yc",
     id="<replace-me>",
     folder_id="adadadadad",
     location={
@@ -30,9 +30,9 @@ env = Env(
     users={},
     apps={},
     import_secrets={},
-    registry={"type": "gar", "url": "registry"},
-    dns={"domain": "example.com", "type": "cloud-dns"},
-    tf_backend={"type": "gcs", "configs": {"bucket": "some-tf-state"}},
+    registry={"type": "ycr", "url": "registry"},
+    dns={"domain": "example.com", "type": "yc"},
+    tf_backend={"type": "s3", "configs": {"bucket": "some-tf-state"}},
     cloud=cloud,
     kubernetes={"enabled": False},
 )

--- a/rod/scripts/init/tf/prepare/tests.py
+++ b/rod/scripts/init/tf/prepare/tests.py
@@ -11,15 +11,16 @@ cloud = Cloud(
     name="<replace-me>",
     id="<replace-me>",
     folder_id="adadadadad",
-    region="ignored",
-    default_zone="",
-    multi_region="",
+    location={
+        "region": "ignored",
+        "default_zone": "",
+        "multi_region": "",
+    },
     network={
         "vm_cidr": "10.8.0.0/20",
         "k8s_pod_cidr": "10.12.0.0/14",
         "k8s_service_cidr": "10.9.0.0/20",
     },
-    registry="registry",
     buckets={"multi_regional": "false"},
 )
 
@@ -29,6 +30,8 @@ env = Env(
     users={},
     apps={},
     import_secrets={},
+    registry={"type": "gar", "url": "registry"},
+    dns={"domain": "example.com", "type": "cloud-dns"},
     tf_backend={"type": "gcs", "configs": {"bucket": "some-tf-state"}},
     cloud=cloud,
     kubernetes={"enabled": False},

--- a/rod/scripts/init/tf/state/create.py
+++ b/rod/scripts/init/tf/state/create.py
@@ -15,7 +15,7 @@ def create_state() -> None:
             created = create_gcs_tf_state(
                 env_obj.cloud.id,
                 env_obj.tf_backend.configs["bucket"],
-                env_obj.cloud.region,
+                env_obj.cloud.location.region,
             )
             if not created:
                 sys.exit(1)

--- a/rod/scripts/init/tf/state/tests.py
+++ b/rod/scripts/init/tf/state/tests.py
@@ -9,15 +9,16 @@ cloud = Cloud(
     name="<replace-me>",
     id="<replace-me>",
     folder_id="adadadadad",
-    region="<replace-me>",
-    default_zone="",
-    multi_region="",
+    location={
+        "region": "<replace-me>",
+        "default_zone": "",
+        "multi_region": "",
+    },
     network={
         "vm_cidr": "10.8.0.0/20",
         "k8s_pod_cidr": "10.12.0.0/14",
         "k8s_service_cidr": "10.9.0.0/20",
     },
-    registry="registry",
     buckets={"multi_regional": "false"},
 )
 
@@ -37,7 +38,7 @@ class TestCreateState(unittest.TestCase):
 
         cloud_gcp.name = "gcp"
         cloud_gcp.id = "project-123"
-        cloud_gcp.region = "europe-west2"
+        cloud_gcp.location.region = "europe-west2"
         tf_backend_gcs.type = "gcs"
 
         env_obj = SimpleNamespace(tf_backend=tf_backend_gcs, cloud=cloud_gcp)
@@ -64,7 +65,7 @@ class TestCreateState(unittest.TestCase):
 
         cloud_yc.id = "asadadadad"
         cloud_yc.name = "yc"
-        cloud_yc.region = "ru-central1"
+        cloud_yc.location.region = "ru-central1"
         tf_backend_ycs3.type = "s3"
 
         env_obj = SimpleNamespace(tf_backend=tf_backend_ycs3, cloud=cloud_yc)
@@ -87,7 +88,7 @@ class TestCreateState(unittest.TestCase):
         tf_backend_gcs_dev = tf_backend.model_copy(deep=True)
 
         cloud_gcp_dev.id = "project-dev"
-        cloud_gcp_dev.region = "europe-north1"
+        cloud_gcp_dev.location.region = "europe-north1"
         tf_backend_gcs_dev.type = "gcs"
         tf_backend_gcs_dev.configs["bucket"] = "bucket-dev"
 
@@ -95,7 +96,7 @@ class TestCreateState(unittest.TestCase):
         tf_backend_gcs_prd = tf_backend.model_copy(deep=True)
 
         cloud_gcp_prd.id = "project-prd"
-        cloud_gcp_prd.region = "us-central1"
+        cloud_gcp_prd.location.region = "us-central1"
         tf_backend_gcs_prd.type = "gcs"
         tf_backend_gcs_prd.configs["bucket"] = "bucket-prd"
 
@@ -130,7 +131,7 @@ class TestCreateState(unittest.TestCase):
 
         cloud_gcp.name = "gcp"
         cloud_gcp.id = "project-123"
-        cloud_gcp.region = "europe-west2"
+        cloud_gcp.location.region = "europe-west2"
         tf_backend_azure.type = "azure"
 
         env_obj = SimpleNamespace(tf_backend=tf_backend_azure, cloud=cloud_gcp)

--- a/rod/scripts/init/tf/state/tests.py
+++ b/rod/scripts/init/tf/state/tests.py
@@ -6,7 +6,7 @@ from rod.scripts.init.tf.state.create import create_state
 from rod.libs.py.tf.tfvars import TfBackend, Cloud
 
 cloud = Cloud(
-    name="<replace-me>",
+    name="gcp",
     id="<replace-me>",
     folder_id="adadadadad",
     location={

--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -5,8 +5,7 @@
   },
   "ci": {
     "type": "gha",
-    "group": "svetoch-dev",
-    "bazelisk_img_version": ""
+    "group": "svetoch-dev"
   },
   "repo": {
     "name": "rod",
@@ -50,18 +49,27 @@
           "prefix": "{env.name}/{tf_backend.state_name}"
         }
       },
+      "registry": {
+        "type": "gar",
+        "url": "{env.cloud.location.region}-docker.pkg.dev/{env.cloud.id}/containers"
+      },
+      "dns": {
+        "domain": "{env.short_name}.{company.domain}",
+        "type": "gcp"
+      },
       "cloud": {
         "name": "gcp",
         "id": "rod-internal",
-        "region": "europe-west2",
-        "default_zone": "europe-west2-c",
-        "multi_region": "EU",
+        "location": {
+          "region": "europe-west2",
+          "default_zone": "europe-west2-c",
+          "multi_region": "EU"
+        },
         "network": {
           "vm_cidr": "10.0.0.0/20",
           "k8s_pod_cidr": "10.4.0.0/14",
           "k8s_service_cidr": "10.1.0.0/20"
         },
-        "registry": "{env.cloud.region}-docker.pkg.dev/{env.cloud.id}/containers",
         "buckets": {
           "multi_regional": "false"
         }
@@ -111,18 +119,27 @@
           "prefix": "{env.name}/{tf_backend.state_name}"
         }
       },
+      "registry": {
+        "type": "gar",
+        "url": "{env.cloud.location.region}-docker.pkg.dev/{env.cloud.id}/containers"
+      },
+      "dns": {
+        "domain": "{env.short_name}.{company.domain}",
+        "type": "gcp"
+      },
       "cloud": {
         "name": "gcp",
         "id": "rod-development",
-        "region": "europe-west2",
-        "default_zone": "europe-west2-a",
-        "multi_region": "EU",
+        "location": {
+          "region": "europe-west2",
+          "default_zone": "europe-west2-a",
+          "multi_region": "EU"
+        },
         "network": {
           "vm_cidr": "10.16.0.0/20",
           "k8s_pod_cidr": "10.20.0.0/14",
           "k8s_service_cidr": "10.17.0.0/20"
         },
-        "registry": "{env.cloud.region}-docker.pkg.dev/{env.cloud.id}/containers",
         "buckets": {
           "multi_regional": "false"
         }
@@ -172,18 +189,27 @@
           "prefix": "{env.name}/{tf_backend.state_name}"
         }
       },
+      "registry": {
+        "type": "gar",
+        "url": "{env.cloud.location.region}-docker.pkg.dev/{env.cloud.id}/containers"
+      },
+      "dns": {
+        "domain": "{env.short_name}.{company.domain}",
+        "type": "gcp"
+      },
       "cloud": {
         "name": "gcp",
         "id": "rod-production",
-        "region": "europe-west2",
-        "default_zone": "europe-west2-c",
-        "multi_region": "EU",
+        "location": {
+          "region": "europe-west2",
+          "default_zone": "europe-west2-c",
+          "multi_region": "EU"
+        },
         "network": {
           "vm_cidr": "10.8.0.0/20",
           "k8s_pod_cidr": "10.12.0.0/14",
           "k8s_service_cidr": "10.9.0.0/20"
         },
-        "registry": "{env.cloud.region}-docker.pkg.dev/{env.cloud.id}/containers",
         "buckets": {
           "multi_regional": "false"
         }

--- a/terraform/tf_variables.tf.tpl
+++ b/terraform/tf_variables.tf.tpl
@@ -30,6 +30,11 @@ variable "ci" {
       bazelisk_img_version = optional(string,"")
     }
   )
+
+  validation {
+    condition     = contains(["gl", "gha"], var.ci.type)
+    error_message = "ci.type must be either \"gl\" or \"gha\"."
+  }
 }
 
 variable "repo" {
@@ -91,6 +96,18 @@ variable "envs" {
             }
           )
         )
+        registry = object(
+          {
+            type = string
+            url  = string
+          }
+        )
+        dns = object(
+          {
+            domain = string
+            type   = string
+          }
+        )
         tf_backend = object(
           {
             type    = string
@@ -102,10 +119,13 @@ variable "envs" {
             name         = string
             id           = string
             folder_id    = optional(string)
-            region       = string
-            default_zone = string
-            multi_region = string
-            registry     = string
+            location     = object(
+              {
+                region       = string
+                default_zone = string
+                multi_region = optional(string, "")
+              }
+            )
             network = object(
               {
                 vm_cidr          = string

--- a/terraform/tf_variables.tf.tpl
+++ b/terraform/tf_variables.tf.tpl
@@ -46,6 +46,11 @@ variable "repo" {
       group = string
     }
   )
+
+  validation {
+    condition     = contains(["github", "gitlab"], var.repo.type)
+    error_message = "repo.type must be either \"github\" or \"gitlab\"."
+  }
 }
 
 variable "envs" {
@@ -153,4 +158,37 @@ variable "envs" {
       }
     )
   )
+
+  validation {
+    condition     = alltrue([for env_name, env_obj in var.envs : contains(["gcp", "yc"], env_obj.cloud.name)])
+    error_message = "envs[*].cloud.name must be either \"gcp\" or \"yc\"."
+  }
+
+  validation {
+    condition     = alltrue([for env_name, env_obj in var.envs : contains(["gcp", "yc"], env_obj.dns.type)])
+    error_message = "envs[*].dns.type must be either \"gcp\" or \"yc\"."
+  }
+
+  validation {
+    condition     = alltrue([for env_name, env_obj in var.envs : contains(["ycr", "gar"], env_obj.registry.type)])
+    error_message = "envs[*].registry.type must be either \"ycr\" or \"gar\"."
+  }
+
+  validation {
+    condition     = alltrue(
+      concat(
+        [
+          for env_name, env_obj in var.envs:
+          env_obj.cloud.folder_id != null && env_obj.cloud.folder_id != ""
+          if env_obj.cloud.name == "yc"
+        ],
+        [
+          for env_name, env_obj in var.envs:
+          true
+          if env_obj.cloud.name != "yc"
+        ],
+      )
+    )
+    error_message = "envs[*].cloud.folder_id must be set when cloud.name is \"yc\"."
+  }
 }

--- a/tools/utils/common.bzl
+++ b/tools/utils/common.bzl
@@ -12,9 +12,9 @@ def build_envs():
     tf_vars = formatted_tfvars()
     for _, env_obj in tf_vars["envs"].items():
         envs[env_obj["short_name"]] = {
-            "registry": env_obj["cloud"]["registry"],
+            "registry": env_obj["registry"]["url"],
             "id": env_obj["cloud"]["id"],
-            "region": env_obj["cloud"]["region"],
+            "region": env_obj["cloud"]["location"]["region"],
         }
 
     return envs

--- a/tools/utils/format.bzl
+++ b/tools/utils/format.bzl
@@ -40,6 +40,7 @@ def formatted_tfvars(state_name = None):
     #Common parameters passed to str.format()
     #used to render templated strings in tfvars var
     replacement_dict = {
+        "company.domain": tfvars["company"]["domain"],
         "company.name": tfvars["company"]["name"],
         "tf_backend.state_name": state_name,
     }
@@ -47,10 +48,16 @@ def formatted_tfvars(state_name = None):
     tf_vars = format_dict(replacement_dict, tfvars)
 
     for env, env_obj in tfvars["envs"].items():
-        replacement_dict["env.cloud.region"] = env_obj["cloud"]["region"]
+        replacement_dict["env.cloud.location.region"] = env_obj["cloud"]["location"]["region"]
+        replacement_dict["env.cloud.location.default_zone"] = env_obj["cloud"]["location"]["default_zone"]
+        replacement_dict["env.cloud.location.multi_region"] = env_obj["cloud"]["location"]["multi_region"]
         replacement_dict["env.cloud.id"] = env_obj["cloud"]["id"]
         replacement_dict["env.name"] = env_obj["name"]
         replacement_dict["env.short_name"] = env_obj["short_name"]
+        replacement_dict["env.registry.type"] = env_obj["registry"]["type"]
+        replacement_dict["env.registry.url"] = env_obj["registry"]["url"]
+        replacement_dict["env.dns.domain"] = env_obj["dns"]["domain"]
+        replacement_dict["env.dns.type"] = env_obj["dns"]["type"]
         replacement_dict["tf_backend.type"] = env_obj["tf_backend"]["type"]
         tf_vars["envs"][env] = format_dict(replacement_dict, env_obj)
 


### PR DESCRIPTION
# v0.17.0

## ⚠️ Breaking Changes:

### terrafrom.tfvars.json schema changes

* `env.cloud.registry` is moved to `env.registry` and type is changed to object
* `env.dns` new mandatory object variable
* `env.cloud.{region,default_zone,multi_region}` attributes are moved under `env.cloud.location`


Features:
* `terrafrom.tfvars.json` variables validation
* `.codex/rules/bazel.rules` codex rules that allow `bazel {build,test} *` commands