### PR TITLE
terraform.tfvars.json new var.envs.type attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# v0.18.0
+
+Braking changes:
+* `rod/lib/py/settings` `tf_template_dir` -> `tf_product_dir`
+
+Features:
+* `terraform.tfvars.json` new mandatory `var.envs[*].type` attribute
+  * use env.type attribute to find internal env
+* `libs/py/settings` add tests
+
+
 # v0.17.0
 
 ## ⚠️ Breaking Changes:

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,3 +1,121 @@
+# v0.18.0
+
+This release adds an explicit environment classification to
+`terraform.tfvars.json` and renames the Terraform product template directory
+setting. Agents upgrading a downstream project should treat this as both a data
+schema migration and a source-code reference migration.
+
+## Agent Upgrade Checklist
+
+1. Update the `svetoch_bazel_lib` `git_override` commit in `MODULE.bazel` to
+   the commit which target release git tag is pointing to.
+2. Open the downstream project's root `terraform.tfvars.json`.
+3. For every object under `envs`, add the required top-level `type` string:
+   - Use `"internal"` for the infrastructure/internal environment.
+   - Use `"product"` for environments that should receive product Terraform
+     templates and app deployment macros.
+4. Do not infer internal environments from `short_name == "int"` anymore.
+   Search downstream code, tests, and docs for these patterns and update them:
+   - `short_name == "int"`
+   - `short_name != "int"`
+   - env key/name checks such as `env_name != "int"` when the intent is to
+     skip internal environments.
+   Replace those checks with `env.type == "internal"` or
+   `env.type == "product"` depending on the intent.
+5. Rename Terraform product template paths:
+   - Rename `terraform/environments/template` to
+     `terraform/environments/product` if that directory exists.
+   - Update references to `bazel_settings.tf_template_dir` to
+     `bazel_settings.tf_product_dir`.
+   - Update references to `tf_template_dir_override` or
+     `TF_TEMPLATE_DIR_OVERRIDE` to `tf_product_dir_override` or
+     `TF_PRODUCT_DIR_OVERRIDE`.
+6. Update tests and fixtures that construct `Env` objects or inline
+   `terraform.tfvars.json` data. Every environment fixture now needs
+   `type = "internal"` or `type = "product"`.
+7. Run a text search after editing. No downstream source should still reference:
+   - `tf_template_dir`
+   - `tf_template_dir_override`
+   - `TF_TEMPLATE_DIR_OVERRIDE`
+   - `short_name == "int"` for environment classification.
+8. Run `bazel test //...` from the downstream repository root. If that is too
+   broad for the context, run at least the Terraform init/apply/prepare targets,
+   lint targets, and any tests that parse `terraform.tfvars.json`.
+
+## terraform.tfvars.json Migration
+
+Old shape:
+
+```json
+{
+  "envs": {
+    "internal": {
+      "name": "internal",
+      "short_name": "int"
+    },
+    "production": {
+      "name": "production",
+      "short_name": "prd"
+    }
+  }
+}
+```
+
+New shape:
+
+```json
+{
+  "envs": {
+    "internal": {
+      "name": "internal",
+      "short_name": "int",
+      "type": "internal"
+    },
+    "production": {
+      "name": "production",
+      "short_name": "prd",
+      "type": "product"
+    }
+  }
+}
+```
+
+The valid values are exactly `"internal"` and `"product"`. Terraform validation
+and the Python tfvars model reject any other value.
+
+## Product Template Directory Migration
+
+The default product-template directory is now:
+
+```text
+terraform/environments/product
+```
+
+instead of:
+
+```text
+terraform/environments/template
+```
+
+Agents should rename the directory, then update any scripts, BUILD targets,
+README files, CI configuration, or tests that refer to the old path. Product
+environment directories are copied from `terraform/environments/product`;
+internal environments are skipped based on `envs[*].type == "internal"`.
+
+## Common Agent Pitfalls
+
+- Do not add `type` under `cloud`, `registry`, or `dns`; it belongs directly
+  under each `envs[*]` object.
+- Do not set `type` to stage names such as `dev`, `prod`, `prd`, or `staging`.
+  Use only `internal` or `product`.
+- Do not keep using `short_name == "int"` as the source of truth. In this
+  release an internal environment can have any short name.
+- Do not leave `terraform/environments/template` in place if the project relies
+  on the library's prepare/copy or poststep clean scripts. Rename it to
+  `terraform/environments/product`.
+- Do not update production-like environments only. Every environment entry,
+  including tests and examples, must include `type`.
+
 # v0.17.0
 
 This release changes the `terraform.tfvars.json` schema consumed by

--- a/constants.bzl
+++ b/constants.bzl
@@ -1,3 +1,0 @@
-"""File for defining constants"""
-
-TF_ENVS_PATH = "//terraform/environments"

--- a/rod/libs/py/settings/BUILD.bazel
+++ b/rod/libs/py/settings/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@aspect_rules_py//py:defs.bzl", "py_library")
+load("@aspect_rules_py//py:defs.bzl", "py_library", "py_test")
 load("@svetoch_bazel_lib//tools/lint/py:black.bzl", "py_lint")
 load("@svetoch_bazel_lib_py_deps//:requirements.bzl", "requirement")
 
@@ -13,4 +13,10 @@ py_library(
     deps = [
         requirement("pydantic-settings"),
     ],
+)
+
+py_test(
+    name = "tests",
+    srcs = ["tests.py"],
+    deps = [":settings"],
 )

--- a/rod/libs/py/settings/__init__.py
+++ b/rod/libs/py/settings/__init__.py
@@ -15,29 +15,29 @@ class BazelSettings(BaseSettings):
     tf_dir_override: str | None = None
 
     tf_env_dir_override: str | None = None
-    tf_template_dir_override: str | None = None
+    tf_product_dir_override: str | None = None
 
     @computed_field
     @property
     # Relative to workspace root
     def tf_dir(self) -> str:
         if self.tf_dir_override:
-            return tf_dir_override
+            return self.tf_dir_override
         return f"terraform"
 
     @computed_field
     @property
     def tf_env_dir(self) -> str:
         if self.tf_env_dir_override:
-            return tf_env_dir_override
+            return self.tf_env_dir_override
         return f"{self.tf_dir}/environments"
 
     @computed_field
     @property
-    def tf_template_dir(self) -> str:
-        if self.tf_template_dir_override:
-            return tf_template_dir_override
-        return f"{self.tf_env_dir}/template"
+    def tf_product_dir(self) -> str:
+        if self.tf_product_dir_override:
+            return self.tf_product_dir_override
+        return f"{self.tf_env_dir}/product"
 
     @computed_field
     @property

--- a/rod/libs/py/settings/tests.py
+++ b/rod/libs/py/settings/tests.py
@@ -1,0 +1,35 @@
+import unittest
+
+from rod.libs.py.settings import BazelSettings
+
+
+class TestBazelSettings(unittest.TestCase):
+    def test_default_tf_paths_are_relative_to_workspace(self):
+        settings = BazelSettings(BUILD_WORKSPACE_DIRECTORY="/workspace")
+
+        self.assertEqual(settings.tf_dir, "terraform")
+        self.assertEqual(settings.tf_env_dir, "terraform/environments")
+        self.assertEqual(settings.tf_product_dir, "terraform/environments/product")
+        self.assertEqual(settings.tfvars_file, "/workspace/terraform.tfvars.json")
+
+    def test_tf_dir_override_updates_derived_paths(self):
+        settings = BazelSettings(tf_dir_override="infra")
+
+        self.assertEqual(settings.tf_dir, "infra")
+        self.assertEqual(settings.tf_env_dir, "infra/environments")
+        self.assertEqual(settings.tf_product_dir, "infra/environments/product")
+
+    def test_tf_env_dir_override_updates_product_path(self):
+        settings = BazelSettings(tf_env_dir_override="infra/envs")
+
+        self.assertEqual(settings.tf_env_dir, "infra/envs")
+        self.assertEqual(settings.tf_product_dir, "infra/envs/product")
+
+    def test_tf_product_dir_override_is_used_directly(self):
+        settings = BazelSettings(tf_product_dir_override="infra/products")
+
+        self.assertEqual(settings.tf_product_dir, "infra/products")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/rod/libs/py/tf/test_tfvars.py
+++ b/rod/libs/py/tf/test_tfvars.py
@@ -1,4 +1,6 @@
 import unittest
+from copy import deepcopy
+
 from pydantic import ValidationError
 from rod.libs.py.tf.tfvars import (
     formatted_tfvars,
@@ -20,6 +22,42 @@ from rod.libs.py.tf.tfvars import (
 
 class TestFormattedTfvars(unittest.TestCase):
     """Test suite for checking that template terraform.tfvars.json is rendered properly."""
+
+    def _env(self, env_type):
+        return {
+            "name": env_type,
+            "short_name": env_type[:3],
+            "type": env_type,
+            "users": {},
+            "apps": {},
+            "import_secrets": {},
+            "registry": {"type": "gar", "url": "registry.example.com"},
+            "dns": {"domain": "example.com", "type": "gcp"},
+            "tf_backend": {"type": "gcs", "configs": {"bucket": "tf-state"}},
+            "cloud": {
+                "name": "gcp",
+                "id": env_type,
+                "location": {
+                    "region": "europe-west2",
+                    "default_zone": "europe-west2-a",
+                },
+                "network": {
+                    "vm_cidr": "10.8.0.0/20",
+                    "k8s_pod_cidr": "10.12.0.0/14",
+                    "k8s_service_cidr": "10.9.0.0/20",
+                },
+                "buckets": {"multi_regional": True},
+            },
+            "kubernetes": {"enabled": False},
+        }
+
+    def _tfvars(self, envs):
+        return {
+            "company": {"name": "test", "domain": "example.com"},
+            "repo": {"name": "test", "type": "github", "group": "test"},
+            "ci": {"type": "gha", "group": "test"},
+            "envs": envs,
+        }
 
     def test_formatted_tfvars_replaces_top_level_and_env_placeholders(self):
 
@@ -117,132 +155,65 @@ class TestFormattedTfvars(unittest.TestCase):
             Repo(name="test", type="gha", group="test")
 
     def test_env_type_accepts_supported_values(self):
-        env = {
-            "name": "test",
-            "short_name": "tst",
-            "users": {},
-            "apps": {},
-            "import_secrets": {},
-            "registry": {"type": "gar", "url": "registry.example.com"},
-            "dns": {"domain": "example.com", "type": "gcp"},
-            "tf_backend": {"type": "gcs", "configs": {"bucket": "tf-state"}},
-            "cloud": {
-                "name": "gcp",
-                "id": "test",
-                "location": {
-                    "region": "europe-west2",
-                    "default_zone": "europe-west2-a",
-                },
-                "network": {
-                    "vm_cidr": "10.8.0.0/20",
-                    "k8s_pod_cidr": "10.12.0.0/14",
-                    "k8s_service_cidr": "10.9.0.0/20",
-                },
-                "buckets": {"multi_regional": True},
-            },
-            "kubernetes": {"enabled": False},
-        }
-
-        self.assertEqual(Env(type="internal", **env).type, "internal")
-        self.assertEqual(Env(type="product", **env).type, "product")
+        self.assertEqual(Env(**self._env("internal")).type, "internal")
+        self.assertEqual(Env(**self._env("product")).type, "product")
 
     def test_env_type_rejects_unsupported_values(self):
         with self.assertRaises(ValidationError):
-            Env(
-                name="test",
-                short_name="tst",
-                type="staging",
-                users={},
-                apps={},
-                import_secrets={},
-                registry={"type": "gar", "url": "registry.example.com"},
-                dns={"domain": "example.com", "type": "gcp"},
-                tf_backend={"type": "gcs", "configs": {"bucket": "tf-state"}},
-                cloud={
-                    "name": "gcp",
-                    "id": "test",
-                    "location": {
-                        "region": "europe-west2",
-                        "default_zone": "europe-west2-a",
-                    },
-                    "network": {
-                        "vm_cidr": "10.8.0.0/20",
-                        "k8s_pod_cidr": "10.12.0.0/14",
-                        "k8s_service_cidr": "10.9.0.0/20",
-                    },
-                    "buckets": {"multi_regional": True},
-                },
-                kubernetes={"enabled": False},
-            )
+            Env(**self._env("staging"))
+
+    def test_tfvars_accepts_single_internal_env(self):
+        envs = {
+            "internal": self._env("internal"),
+            "production": self._env("product"),
+        }
+
+        self.assertEqual(
+            TfVars.model_validate(self._tfvars(envs)).envs["internal"].type, "internal"
+        )
+
+    def test_tfvars_rejects_missing_internal_env(self):
+        envs = {
+            "development": self._env("product"),
+            "production": self._env("product"),
+        }
+
+        with self.assertRaises(ValidationError):
+            TfVars.model_validate(self._tfvars(envs))
+
+    def test_tfvars_rejects_multiple_internal_envs(self):
+        first_internal = self._env("internal")
+        second_internal = deepcopy(first_internal)
+        second_internal["name"] = "another-internal"
+        second_internal["short_name"] = "ain"
+
+        envs = {
+            "internal": first_internal,
+            "another_internal": second_internal,
+            "production": self._env("product"),
+        }
+
+        with self.assertRaises(ValidationError):
+            TfVars.model_validate(self._tfvars(envs))
 
     def test_cloud_name_accepts_supported_values(self):
-        cloud = {
-            "id": "test",
-            "location": {
-                "region": "europe-west2",
-                "default_zone": "europe-west2-a",
-            },
-            "network": {
-                "vm_cidr": "10.8.0.0/20",
-                "k8s_pod_cidr": "10.12.0.0/14",
-                "k8s_service_cidr": "10.9.0.0/20",
-            },
-            "buckets": {"multi_regional": True},
-        }
+        cloud = self._env("internal")["cloud"]
+        del cloud["name"]
 
         self.assertEqual(Cloud(name="gcp", **cloud).name, "gcp")
         self.assertEqual(Cloud(name="yc", folder_id="yc-folder", **cloud).name, "yc")
 
     def test_cloud_name_rejects_unsupported_values(self):
+        cloud = self._env("internal")["cloud"]
+        cloud["name"] = "none_existant_cloud"
         with self.assertRaises(ValidationError):
-            Cloud(
-                name="none_existant_cloud",
-                id="test",
-                location={
-                    "region": "europe-west2",
-                    "default_zone": "europe-west2-a",
-                },
-                network={
-                    "vm_cidr": "10.8.0.0/20",
-                    "k8s_pod_cidr": "10.12.0.0/14",
-                    "k8s_service_cidr": "10.9.0.0/20",
-                },
-                buckets={"multi_regional": True},
-            )
+            Cloud(**cloud)
 
     def test_yc_cloud_requires_folder_id(self):
+        cloud = self._env("internal")["cloud"]
+        cloud["name"] = "yc"
         with self.assertRaises(ValidationError):
-            Cloud(
-                name="yc",
-                id="test",
-                location={
-                    "region": "ru-central1",
-                    "default_zone": "ru-central1-a",
-                },
-                network={
-                    "vm_cidr": "10.8.0.0/20",
-                    "k8s_pod_cidr": "10.12.0.0/14",
-                    "k8s_service_cidr": "10.9.0.0/20",
-                },
-                buckets={"multi_regional": False},
-            )
-
-        with self.assertRaises(ValidationError):
-            Cloud(
-                name="yc",
-                id="test",
-                folder_id="",
-                location={
-                    "region": "ru-central1",
-                    "default_zone": "ru-central1-a",
-                },
-                network={
-                    "vm_cidr": "10.8.0.0/20",
-                    "k8s_pod_cidr": "10.12.0.0/14",
-                    "k8s_service_cidr": "10.9.0.0/20",
-                },
-                buckets={"multi_regional": False},
-            )
+            Cloud(**cloud)
 
     def test_dns_type_accepts_supported_values(self):
         self.assertEqual(Dns(domain="example.com", type="gcp").type, "gcp")

--- a/rod/libs/py/tf/test_tfvars.py
+++ b/rod/libs/py/tf/test_tfvars.py
@@ -50,6 +50,7 @@ class TestFormattedTfvars(unittest.TestCase):
         self.assertEqual(prd.cloud.location.multi_region, "EU")
         self.assertEqual(prd.dns.domain, "prd.rod.svetoch.dev")
         self.assertEqual(prd.dns.type, "gcp")
+        self.assertEqual(prd.type, "product")
         self.assertEqual(prd.registry.type, "gar")
         self.assertEqual(
             prd.registry.url, "europe-west2-docker.pkg.dev/rod-production/containers"
@@ -114,6 +115,65 @@ class TestFormattedTfvars(unittest.TestCase):
     def test_repo_type_rejects_unsupported_values(self):
         with self.assertRaises(ValidationError):
             Repo(name="test", type="gha", group="test")
+
+    def test_env_type_accepts_supported_values(self):
+        env = {
+            "name": "test",
+            "short_name": "tst",
+            "users": {},
+            "apps": {},
+            "import_secrets": {},
+            "registry": {"type": "gar", "url": "registry.example.com"},
+            "dns": {"domain": "example.com", "type": "gcp"},
+            "tf_backend": {"type": "gcs", "configs": {"bucket": "tf-state"}},
+            "cloud": {
+                "name": "gcp",
+                "id": "test",
+                "location": {
+                    "region": "europe-west2",
+                    "default_zone": "europe-west2-a",
+                },
+                "network": {
+                    "vm_cidr": "10.8.0.0/20",
+                    "k8s_pod_cidr": "10.12.0.0/14",
+                    "k8s_service_cidr": "10.9.0.0/20",
+                },
+                "buckets": {"multi_regional": True},
+            },
+            "kubernetes": {"enabled": False},
+        }
+
+        self.assertEqual(Env(type="internal", **env).type, "internal")
+        self.assertEqual(Env(type="product", **env).type, "product")
+
+    def test_env_type_rejects_unsupported_values(self):
+        with self.assertRaises(ValidationError):
+            Env(
+                name="test",
+                short_name="tst",
+                type="staging",
+                users={},
+                apps={},
+                import_secrets={},
+                registry={"type": "gar", "url": "registry.example.com"},
+                dns={"domain": "example.com", "type": "gcp"},
+                tf_backend={"type": "gcs", "configs": {"bucket": "tf-state"}},
+                cloud={
+                    "name": "gcp",
+                    "id": "test",
+                    "location": {
+                        "region": "europe-west2",
+                        "default_zone": "europe-west2-a",
+                    },
+                    "network": {
+                        "vm_cidr": "10.8.0.0/20",
+                        "k8s_pod_cidr": "10.12.0.0/14",
+                        "k8s_service_cidr": "10.9.0.0/20",
+                    },
+                    "buckets": {"multi_regional": True},
+                },
+                kubernetes={"enabled": False},
+            )
 
     def test_cloud_name_accepts_supported_values(self):
         cloud = {

--- a/rod/libs/py/tf/tfvars.py
+++ b/rod/libs/py/tf/tfvars.py
@@ -94,6 +94,7 @@ class Cloud(BaseTfVarsModel):
 class Env(BaseTfVarsModel):
     name: str
     short_name: str
+    type: Literal["internal", "product"]
     initial_start: bool = False
     users: dict[str, User]
     apps: dict[str, App]

--- a/rod/libs/py/tf/tfvars.py
+++ b/rod/libs/py/tf/tfvars.py
@@ -129,6 +129,19 @@ class TfVars(BaseTfVarsModel):
     ci: Ci
     envs: dict[str, Env]
 
+    @model_validator(mode="after")
+    def validate_single_internal_env(self):
+        internal_envs = [
+            env_name
+            for env_name, env_obj in self.envs.items()
+            if env_obj.type == "internal"
+        ]
+
+        if len(internal_envs) != 1:
+            raise ValueError('exactly one env type must be "internal"')
+
+        return self
+
 
 def tfvars():
     with open(bazel_settings.tfvars_file, "r") as f:

--- a/rod/scripts/init/tf/apply/apply.py
+++ b/rod/scripts/init/tf/apply/apply.py
@@ -28,7 +28,7 @@ def apply() -> None:
         # initial_start = False
         # 5. Apply everything again
         env_obj.initial_start = False
-        if env_obj.short_name == "int":
+        if env_obj.type == "internal":
             int_env = env_obj.model_copy(deep=True)
 
         envs.append(env_obj)

--- a/rod/scripts/init/tf/apply/tests.py
+++ b/rod/scripts/init/tf/apply/tests.py
@@ -25,7 +25,7 @@ cloud = Cloud(
 env = Env(
     name="<replace-me>",
     short_name="<replace-me>",
-    type="product",
+    type="internal",
     users={},
     apps={},
     initial_start=True,
@@ -44,7 +44,7 @@ tfvars = TfVars(
         "type": "gha",
         "group": "test",
     },
-    envs={},
+    envs={"int": env},
 )
 
 
@@ -74,9 +74,9 @@ class TestApply(unittest.TestCase):
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
         env_prd.short_name = "prd"
+        env_prd.type = "product"
 
         tf_vars = tfvars.model_copy(deep=True)
-
         tf_vars.envs = {"int": env_int, "prd": env_prd}
 
         mock_tfvars.return_value = tf_vars
@@ -136,6 +136,7 @@ class TestApply(unittest.TestCase):
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
         env_prd.short_name = "prd"
+        env_prd.type = "product"
 
         tf_vars = tfvars.model_copy(deep=True)
 
@@ -189,6 +190,7 @@ class TestApply(unittest.TestCase):
 
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
+        env_prd.type = "product"
         env_prd.short_name = "prd"
 
         tf_vars = tfvars.model_copy(deep=True)
@@ -250,6 +252,7 @@ class TestApply(unittest.TestCase):
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
         env_prd.short_name = "prd"
+        env_prd.type = "product"
 
         tf_vars = tfvars.model_copy(deep=True)
         tf_vars.envs = {"int": env_int, "prd": env_prd}

--- a/rod/scripts/init/tf/apply/tests.py
+++ b/rod/scripts/init/tf/apply/tests.py
@@ -25,6 +25,7 @@ cloud = Cloud(
 env = Env(
     name="<replace-me>",
     short_name="<replace-me>",
+    type="product",
     users={},
     apps={},
     initial_start=True,
@@ -68,6 +69,7 @@ class TestApply(unittest.TestCase):
         env_int = env.model_copy(deep=True)
         env_int.name = "internal"
         env_int.short_name = "int"
+        env_int.type = "internal"
 
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
@@ -129,6 +131,7 @@ class TestApply(unittest.TestCase):
         env_int = env.model_copy(deep=True)
         env_int.name = "internal"
         env_int.short_name = "int"
+        env_int.type = "internal"
 
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
@@ -182,6 +185,7 @@ class TestApply(unittest.TestCase):
         env_int = env.model_copy(deep=True)
         env_int.name = "internal"
         env_int.short_name = "int"
+        env_int.type = "internal"
 
         env_prd = env.model_copy(deep=True)
         env_prd.name = "production"
@@ -220,6 +224,62 @@ class TestApply(unittest.TestCase):
             ],
         )
         mock_path.assert_called_once_with("/tmp/workspace/terraform.tfvars.json")
+
+    @patch("rod.scripts.init.tf.apply.apply.Path")
+    @patch("rod.scripts.init.tf.apply.apply.apply_env")
+    @patch("rod.scripts.init.tf.apply.apply.tfvars")
+    @patch("rod.scripts.init.tf.apply.apply.os.chdir")
+    @patch("rod.scripts.init.tf.apply.apply.bazel_settings")
+    def test_apply_uses_env_type_to_apply_internal_env_first(
+        self,
+        mock_bazel_settings,
+        mock_chdir,
+        mock_tfvars,
+        mock_apply_env,
+        mock_path,
+    ):
+        mock_bazel_settings.workspace = "/tmp/workspace"
+        mock_bazel_settings.tf_env_dir = "terraform/environments"
+        mock_bazel_settings.tfvars_file = "/tmp/workspace/terraform.tfvars.json"
+
+        env_int = env.model_copy(deep=True)
+        env_int.name = "internal"
+        env_int.short_name = "int"
+        env_int.type = "internal"
+
+        env_prd = env.model_copy(deep=True)
+        env_prd.name = "production"
+        env_prd.short_name = "prd"
+
+        tf_vars = tfvars.model_copy(deep=True)
+        tf_vars.envs = {"int": env_int, "prd": env_prd}
+
+        mock_tfvars.return_value = tf_vars
+        mock_apply_env.return_value = True
+
+        apply()
+
+        self.assertEqual(
+            mock_apply_env.call_args_list,
+            [
+                call(
+                    "int",
+                    exclude_targets=["//terraform/environments/int/secrets:apply"],
+                ),
+                call(
+                    "prd",
+                    exclude_targets=["//terraform/environments/prd/secrets:apply"],
+                ),
+                call(
+                    "int",
+                    exclude_targets=["//terraform/environments/int/secrets:apply"],
+                ),
+                call(
+                    "prd",
+                    exclude_targets=["//terraform/environments/prd/secrets:apply"],
+                ),
+            ],
+        )
 
 
 if __name__ == "__main__":

--- a/rod/scripts/init/tf/poststeps/clean.py
+++ b/rod/scripts/init/tf/poststeps/clean.py
@@ -5,7 +5,7 @@ from rod.libs.py.settings import bazel_settings
 
 def clean() -> None:
     os.chdir(bazel_settings.workspace)
-    shutil.rmtree(bazel_settings.tf_template_dir)
+    shutil.rmtree(bazel_settings.tf_product_dir)
 
 
 if __name__ == "__main__":

--- a/rod/scripts/init/tf/prepare/copy.py
+++ b/rod/scripts/init/tf/prepare/copy.py
@@ -6,21 +6,21 @@ from rod.libs.py.utils.logger import CliLogger
 import sys
 import os
 
-TEMPLATE_DIR = Path(bazel_settings.tf_template_dir)
+PRODUCT_DIR = Path(bazel_settings.tf_product_dir)
 
 
 def copy_template() -> None:
     tfvars = formatted_tfvars()
     logger = CliLogger("rod.scripts.init.tf.prepare.copy")
-    if not TEMPLATE_DIR.exists():
-        logger.error(f"{TEMPLATE_DIR} is not found")
+    if not PRODUCT_DIR.exists():
+        logger.error(f"{PRODUCT_DIR} is not found")
         sys.exit(1)
 
     for env_name, env_obj in tfvars.envs.items():
         copy_to_dir = Path(bazel_settings.tf_env_dir + "/" + env_name)
-        if env_obj.short_name != "int" and not copy_to_dir.exists():
-            copytree(TEMPLATE_DIR, copy_to_dir)
-            logger.info(f"{TEMPLATE_DIR} copied to {copy_to_dir}")
+        if env_obj.type != "internal" and not copy_to_dir.exists():
+            copytree(PRODUCT_DIR, copy_to_dir)
+            logger.info(f"{PRODUCT_DIR} copied to {copy_to_dir}")
 
 
 if __name__ == "__main__":

--- a/rod/scripts/init/tf/prepare/tests.py
+++ b/rod/scripts/init/tf/prepare/tests.py
@@ -27,6 +27,7 @@ cloud = Cloud(
 env = Env(
     name="<replace-me>",
     short_name="<replace-me>",
+    type="product",
     users={},
     apps={},
     import_secrets={},
@@ -39,9 +40,7 @@ env = Env(
 
 
 class TestCopyTemplate(unittest.TestCase):
-    @patch(
-        "rod.scripts.init.tf.prepare.copy.TEMPLATE_DIR", Path("/tmp/tf/env/template")
-    )
+    @patch("rod.scripts.init.tf.prepare.copy.PRODUCT_DIR", Path("/tmp/tf/env/product"))
     @patch("rod.scripts.init.tf.prepare.copy.sys.exit")
     @patch("rod.scripts.init.tf.prepare.copy.Path.exists")
     @patch("rod.scripts.init.tf.prepare.copy.formatted_tfvars")
@@ -72,9 +71,7 @@ class TestCopyTemplate(unittest.TestCase):
 
         mock_sys_exit.assert_called_once_with(1)
 
-    @patch(
-        "rod.scripts.init.tf.prepare.copy.TEMPLATE_DIR", Path("/tmp/tf/env/template")
-    )
+    @patch("rod.scripts.init.tf.prepare.copy.PRODUCT_DIR", Path("/tmp/tf/env/product"))
     @patch("rod.scripts.init.tf.prepare.copy.copytree")
     @patch("rod.scripts.init.tf.prepare.copy.Path.exists")
     @patch("rod.scripts.init.tf.prepare.copy.formatted_tfvars")
@@ -107,16 +104,14 @@ class TestCopyTemplate(unittest.TestCase):
 
         mock_copytree.assert_has_calls(
             [
-                call(Path("/tmp/tf/env/template"), Path("/tmp/tf/env/development")),
-                call(Path("/tmp/tf/env/template"), Path("/tmp/tf/env/production")),
+                call(Path("/tmp/tf/env/product"), Path("/tmp/tf/env/development")),
+                call(Path("/tmp/tf/env/product"), Path("/tmp/tf/env/production")),
             ],
             any_order=False,
         )
         self.assertEqual(mock_copytree.call_count, 2)
 
-    @patch(
-        "rod.scripts.init.tf.prepare.copy.TEMPLATE_DIR", Path("/tmp/tf/env/template")
-    )
+    @patch("rod.scripts.init.tf.prepare.copy.PRODUCT_DIR", Path("/tmp/tf/env/product"))
     @patch("rod.scripts.init.tf.prepare.copy.copytree")
     @patch("rod.scripts.init.tf.prepare.copy.Path.exists")
     @patch("rod.scripts.init.tf.prepare.copy.formatted_tfvars")

--- a/terraform.tfvars.json
+++ b/terraform.tfvars.json
@@ -16,6 +16,7 @@
     "internal": {
       "name": "internal",
       "short_name": "int",
+      "type": "internal",
       "users": {},
       "apps": {},
       "import_secrets": {
@@ -86,6 +87,7 @@
       "name": "development",
       "users": {},
       "short_name": "dev",
+      "type": "product",
       "apps": {
         "example": {
           "name": "example",
@@ -155,6 +157,7 @@
     "production": {
       "name": "production",
       "short_name": "prd",
+      "type": "product",
       "users": {},
       "apps": {
         "example": {

--- a/terraform/tf_variables.tf.tpl
+++ b/terraform/tf_variables.tf.tpl
@@ -181,6 +181,11 @@ variable "envs" {
   }
 
   validation {
+    condition     = length([for env_name, env_obj in var.envs : env_name if env_obj.type == "internal"]) == 1
+    error_message = "Exactly one envs[*].type must be \"internal\"."
+  }
+
+  validation {
     condition     = alltrue(
       concat(
         [

--- a/terraform/tf_variables.tf.tpl
+++ b/terraform/tf_variables.tf.tpl
@@ -60,6 +60,7 @@ variable "envs" {
       {
         name          = string
         short_name    = string
+        type          = string
         initial_start = optional(bool, false)
         users = map(
           object(
@@ -172,6 +173,11 @@ variable "envs" {
   validation {
     condition     = alltrue([for env_name, env_obj in var.envs : contains(["ycr", "gar"], env_obj.registry.type)])
     error_message = "envs[*].registry.type must be either \"ycr\" or \"gar\"."
+  }
+
+  validation {
+    condition     = alltrue([for env_name, env_obj in var.envs : contains(["internal", "product"], env_obj.type)])
+    error_message = "envs[*].type must be either \"internal\" or \"product\"."
   }
 
   validation {

--- a/tools/utils/common.bzl
+++ b/tools/utils/common.bzl
@@ -15,6 +15,7 @@ def build_envs():
             "registry": env_obj["registry"]["url"],
             "id": env_obj["cloud"]["id"],
             "region": env_obj["cloud"]["location"]["region"],
+            "type": env_obj["cloud"]["type"],
         }
 
     return envs

--- a/tools/utils/common.bzl
+++ b/tools/utils/common.bzl
@@ -15,7 +15,7 @@ def build_envs():
             "registry": env_obj["registry"]["url"],
             "id": env_obj["cloud"]["id"],
             "region": env_obj["cloud"]["location"]["region"],
-            "type": env_obj["cloud"]["type"],
+            "type": env_obj["type"],
         }
 
     return envs

--- a/tools/utils/common.bzl
+++ b/tools/utils/common.bzl
@@ -29,6 +29,6 @@ def app_envs():
     envs = {}
 
     for env_name, env_obj in build_envs().items():
-        if env_name != "int":
+        if env_obj["type"] == "product":
             envs[env_name] = env_obj
     return envs

--- a/tools/utils/format.bzl
+++ b/tools/utils/format.bzl
@@ -54,6 +54,7 @@ def formatted_tfvars(state_name = None):
         replacement_dict["env.cloud.id"] = env_obj["cloud"]["id"]
         replacement_dict["env.name"] = env_obj["name"]
         replacement_dict["env.short_name"] = env_obj["short_name"]
+        replacement_dict["env.type"] = env_obj["type"]
         replacement_dict["env.registry.type"] = env_obj["registry"]["type"]
         replacement_dict["env.registry.url"] = env_obj["registry"]["url"]
         replacement_dict["env.dns.domain"] = env_obj["dns"]["domain"]


### PR DESCRIPTION
# v0.18.0

Braking changes:
* `rod/lib/py/settings` `tf_template_dir` -> `tf_product_dir`

Features:
* `terraform.tfvars.json` new mandatory `var.envs[*].type` attribute
  * use env.type attribute to find internal env
* `libs/py/settings` add tests