### PR TITLE
create secret tf state files upon init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# v0.21.0
+
+Features:
+* `rod/libs/py/yc/bucket` YcBucketObject class
+* `rod/scripts/init/tf/state` create empty statefile for secrets root module
+
+Enhancements:
+* `rod/scripts/init/tf/state` run yande related code only if type is s3 and s3_endpoint is `https://storage.yandexcloud.net`
+
 # v0.20.0
 
 Features:

--- a/rod/libs/py/settings/__init__.py
+++ b/rod/libs/py/settings/__init__.py
@@ -10,6 +10,12 @@ class YcSettings(BaseSettings):
     )
 
 
+class AWSSettings(BaseSettings):
+    s3_endpoint: str = Field(
+        validation_alias="AWS_ENDPOINT_URL_S3", default="https://s3.amazonaws.com"
+    )
+
+
 class LogSettings(BaseSettings):
     log_level: str = "INFO"
 

--- a/rod/libs/py/tf/apply.py
+++ b/rod/libs/py/tf/apply.py
@@ -61,8 +61,7 @@ def apply_env(
         execution fails.
     """
 
-    if not logger:
-        logger = CliLogger("rod.libs.py.tf.apply.apply_env")
+    logger = logger or CliLogger("rod.libs.py.tf.apply.apply_env")
 
     exclude_targets = exclude_targets or []
 

--- a/rod/libs/py/tf/secrets.py
+++ b/rod/libs/py/tf/secrets.py
@@ -10,8 +10,7 @@ def import_secrets(
     secrets: dict[str, ImportSecret],
     logger: BaseLogger = None,
 ) -> bool:
-    if not logger:
-        logger = CliLogger("rod.libs.py.tf.secrets.import_secrets")
+    logger = logger or CliLogger("rod.libs.py.tf.secrets.import_secrets")
 
     os.chdir(bazel_settings.workspace)
     secrets_package = f"//{bazel_settings.tf_env_dir}/{env}/secrets"

--- a/rod/libs/py/tf/secrets.py
+++ b/rod/libs/py/tf/secrets.py
@@ -8,8 +8,11 @@ from rod.libs.py.utils.logger import CliLogger, BaseLogger
 def import_secrets(
     env: str,
     secrets: dict[str, ImportSecret],
-    logger: BaseLogger = CliLogger("rod.libs.py.tf.secrets.import_secrets"),
+    logger: BaseLogger = None,
 ) -> bool:
+    if not logger:
+        logger = CliLogger("rod.libs.py.tf.secrets.import_secrets")
+
     os.chdir(bazel_settings.workspace)
     secrets_package = f"//{bazel_settings.tf_env_dir}/{env}/secrets"
     state_list_command = ["bazel", "run", f"{secrets_package}:tf", "state", "list"]

--- a/rod/libs/py/tf/state.py
+++ b/rod/libs/py/tf/state.py
@@ -48,8 +48,7 @@ def create_gcs_tf_state(
         True if the bucket already exists or is created successfully.
         False if bucket creation fails due to an unexpected error.
     """
-    if not logger:
-        logger = CliLogger("rod.libs.py.tf.state.create_gcs_tf_state")
+    logger = logger or CliLogger("rod.libs.py.tf.state.create_gcs_tf_state")
 
     client = storage.Client(project=project_id)
 
@@ -109,8 +108,7 @@ def create_yc_s3_tf_state(
         if bucket setup, lifecycle configuration, access binding update, or
         secrets state object creation fails.
     """
-    if not logger:
-        logger = CliLogger("rod.libs.py.tf.state.create_yc_s3_tf_state")
+    logger = logger or CliLogger("rod.libs.py.tf.state.create_yc_s3_tf_state")
 
     configs = YcBucketConfigs()
     configs.versioning = VERSIONING_ENABLED

--- a/rod/libs/py/tf/state.py
+++ b/rod/libs/py/tf/state.py
@@ -1,11 +1,28 @@
+import json
+import uuid
+
 from google.cloud import storage
 from google.api_core.exceptions import NotFound
 from rod.libs.py.utils.logger import CliLogger, BaseLogger
-from rod.libs.py.yc.bucket import YcBucketConfigs, YcBucket
+from rod.libs.py.yc.bucket import YcBucketConfigs, YcBucket, YcBucketObject
 
 from yandex.cloud.storage.v1.bucket_pb2 import VERSIONING_ENABLED, LifecycleRule
 from google.protobuf.wrappers_pb2 import Int64Value, StringValue
 from yandex.cloud.access.access_pb2 import Subject
+
+
+def empty_state_file() -> bytes:
+    """Return a minimal empty Terraform state file payload."""
+    state = {
+        "version": 4,
+        "terraform_version": "1.14.4",
+        "serial": 1,
+        "lineage": str(uuid.uuid4()),
+        "outputs": {},
+        "resources": [],
+        "check_results": None,
+    }
+    return json.dumps(state, indent=2).encode("utf-8")
 
 
 def create_gcs_tf_state(
@@ -68,6 +85,7 @@ def create_yc_s3_tf_state(
     folder_id: str,
     bucket_name: str,
     sa_id: str,
+    secrets_state: str,
     logger: BaseLogger = None,
 ) -> bool:
     """Ensure that a Yandex Object Storage bucket for Terraform state exists.
@@ -75,18 +93,21 @@ def create_yc_s3_tf_state(
     The bucket is created with versioning enabled, receives a lifecycle rule
     that removes old noncurrent object versions when the rule is not already
     present, and grants storage.admin to the service account that will read and
-    write Terraform state.
+    write Terraform state. It also writes an empty secrets state file so that
+    the secrets backend exists before secret import runs.
 
     Args:
         folder_id: Yandex Cloud folder ID where the bucket should exist.
         bucket_name: Name of the S3-compatible bucket used for Terraform state.
         sa_id: Service account ID to grant storage.admin on the bucket.
+        secrets_state: Object key for the empty secrets Terraform state file.
         logger: Logger used to print status messages.
 
     Returns:
         True if the bucket exists or is created successfully and the service
-        account admin binding is applied. False if bucket setup, lifecycle
-        configuration, or the access binding update fails.
+        account admin binding and empty secrets state object are applied. False
+        if bucket setup, lifecycle configuration, access binding update, or
+        secrets state object creation fails.
     """
     if not logger:
         logger = CliLogger("rod.libs.py.tf.state.create_yc_s3_tf_state")
@@ -117,7 +138,17 @@ def create_yc_s3_tf_state(
         )
         bucket.add_admin(subject)
 
-        return True
     except Exception as e:
         logger.error(f"yc s3 tf state bucket {bucket_name} access binding error: {e}")
         return False
+
+    try:
+        bucket_object = YcBucketObject(bucket_name, secrets_state)
+        bucket_object.create(empty_state_file(), "application/json")
+    except Exception as e:
+        logger.error(
+            f"yc s3 tf state bucket {bucket_name} could not create empty state file: {e}"
+        )
+        return False
+
+    return True

--- a/rod/libs/py/tf/test_state.py
+++ b/rod/libs/py/tf/test_state.py
@@ -1,3 +1,4 @@
+import json
 import unittest
 from unittest.mock import MagicMock, patch
 from google.api_core.exceptions import NotFound
@@ -6,6 +7,7 @@ from yandex.cloud.storage.v1.bucket_pb2 import VERSIONING_ENABLED
 from rod.libs.py.tf.state import (
     create_gcs_tf_state,
     create_yc_s3_tf_state,
+    empty_state_file,
 )
 
 
@@ -106,20 +108,44 @@ class TestCreateGcsTfState(unittest.TestCase):
 
 
 class TestCreateYcS3TfState(unittest.TestCase):
+    def test_empty_state_file_returns_minimal_terraform_state(self):
+        state = json.loads(empty_state_file().decode("utf-8"))
+
+        self.assertEqual(state["version"], 4)
+        self.assertEqual(state["terraform_version"], "1.14.4")
+        self.assertEqual(state["serial"], 1)
+        self.assertEqual(state["outputs"], {})
+        self.assertEqual(state["resources"], [])
+        self.assertIsNone(state["check_results"])
+        self.assertTrue(state["lineage"])
+
+    @patch("rod.libs.py.tf.state.empty_state_file")
+    @patch("rod.libs.py.tf.state.YcBucketObject")
     @patch("rod.libs.py.tf.state.YcBucket")
-    def test_configures_bucket_lifecycle_and_access(self, mock_bucket_cls):
+    def test_configures_bucket_lifecycle_access_and_secrets_state(
+        self,
+        mock_bucket_cls,
+        mock_bucket_object_cls,
+        mock_empty_state_file,
+    ):
         folder_id = "folder-id"
         bucket_name = "tf-state-bucket"
         service_account_id = "service-account-id"
+        secrets_state = "secrets.tfstate"
+        empty_state = b'{"version": 4}'
 
         bucket = MagicMock()
         mock_bucket_cls.return_value = bucket
+        bucket_object = MagicMock()
+        mock_bucket_object_cls.return_value = bucket_object
+        mock_empty_state_file.return_value = empty_state
         logger = MagicMock()
 
         result = create_yc_s3_tf_state(
             folder_id,
             bucket_name,
             service_account_id,
+            secrets_state,
             logger=logger,
         )
 
@@ -148,6 +174,9 @@ class TestCreateYcS3TfState(unittest.TestCase):
         self.assertEqual(subject.id, service_account_id)
         self.assertEqual(subject.type, "serviceAccount")
 
+        mock_bucket_object_cls.assert_called_once_with(bucket_name, secrets_state)
+        bucket_object.create.assert_called_once_with(empty_state, "application/json")
+
     @patch("rod.libs.py.tf.state.YcBucket")
     def test_returns_false_when_bucket_setup_fails(self, mock_bucket_cls):
         mock_bucket_cls.side_effect = RuntimeError("boom")
@@ -157,14 +186,20 @@ class TestCreateYcS3TfState(unittest.TestCase):
             "folder-id",
             "tf-state-bucket",
             "service-account-id",
+            "secrets.tfstate",
             logger=logger,
         )
 
         self.assertFalse(result)
         logger.error.assert_called_once()
 
+    @patch("rod.libs.py.tf.state.YcBucketObject")
     @patch("rod.libs.py.tf.state.YcBucket")
-    def test_returns_false_when_access_binding_fails(self, mock_bucket_cls):
+    def test_returns_false_when_access_binding_fails(
+        self,
+        mock_bucket_cls,
+        mock_bucket_object_cls,
+    ):
         bucket = MagicMock()
         bucket.add_admin.side_effect = RuntimeError("boom")
         mock_bucket_cls.return_value = bucket
@@ -174,9 +209,42 @@ class TestCreateYcS3TfState(unittest.TestCase):
             "folder-id",
             "tf-state-bucket",
             "service-account-id",
+            "secrets.tfstate",
             logger=logger,
         )
 
         self.assertFalse(result)
         bucket.add_lifecycle_rule.assert_called_once()
+        mock_bucket_object_cls.assert_not_called()
+        logger.error.assert_called_once()
+
+    @patch("rod.libs.py.tf.state.YcBucketObject")
+    @patch("rod.libs.py.tf.state.YcBucket")
+    def test_returns_false_when_secrets_state_creation_fails(
+        self,
+        mock_bucket_cls,
+        mock_bucket_object_cls,
+    ):
+        bucket = MagicMock()
+        mock_bucket_cls.return_value = bucket
+        bucket_object = MagicMock()
+        bucket_object.create.side_effect = RuntimeError("boom")
+        mock_bucket_object_cls.return_value = bucket_object
+        logger = MagicMock()
+
+        result = create_yc_s3_tf_state(
+            "folder-id",
+            "tf-state-bucket",
+            "service-account-id",
+            "secrets.tfstate",
+            logger=logger,
+        )
+
+        self.assertFalse(result)
+        bucket.add_lifecycle_rule.assert_called_once()
+        bucket.add_admin.assert_called_once()
+        mock_bucket_object_cls.assert_called_once_with(
+            "tf-state-bucket",
+            "secrets.tfstate",
+        )
         logger.error.assert_called_once()

--- a/rod/libs/py/yc/BUILD.bazel
+++ b/rod/libs/py/yc/BUILD.bazel
@@ -24,6 +24,7 @@ py_library(
         "@svetoch_bazel_lib//rod/libs/py/utils",
         requirement("grpcio"),
         requirement("protobuf"),
+        requirement("requests"),
         requirement("yandexcloud"),
     ],
 )

--- a/rod/libs/py/yc/bucket.py
+++ b/rod/libs/py/yc/bucket.py
@@ -54,9 +54,7 @@ class YcBucketObject:
         token: str = None,
         logger: BaseLogger = None,
     ):
-        if not logger:
-            logger = CliLogger("rod.libs.py.yc.bucket.BucketObject")
-        self.logger = logger
+        self.logger = logger or CliLogger("rod.libs.py.yc.bucket.BucketObject")
 
         settings = YcSettings()
         if token:
@@ -158,10 +156,8 @@ class YcBucket:
         configs: YcBucketConfigs = None,
         logger: BaseLogger = None,
     ):
-        if not configs:
-            configs = YcBucketConfigs()
-        if not logger:
-            logger = CliLogger("rod.libs.py.yc.bucket.Bucket")
+        conifgs = configs or YcBucketConfigs()
+        logger = logger or CliLogger("rod.libs.py.yc.bucket.Bucket")
 
         self.sdk = sdk_get(token)
         self.folder_id = folder_id

--- a/rod/libs/py/yc/bucket.py
+++ b/rod/libs/py/yc/bucket.py
@@ -23,8 +23,10 @@ from yandex.cloud.storage.v1.bucket_service_pb2 import (
 )
 from yandex.cloud.storage.v1.bucket_service_pb2_grpc import BucketServiceStub
 
+import requests
+
 from rod.libs.py.utils.logger import BaseLogger, CliLogger
-from rod.libs.py.yc.client import sdk_get
+from rod.libs.py.yc.client import AuthError, YcSettings, sdk_get
 
 
 @dataclass
@@ -40,6 +42,103 @@ class YcBucketConfigs:
         )
     )
     versioning: Versioning = VERSIONING_DISABLED
+
+
+class YcBucketObject:
+    """Manage a single object in a Yandex Object Storage bucket over HTTP."""
+
+    def __init__(
+        self,
+        bucket: str,
+        key: str,
+        token: str = None,
+        logger: BaseLogger = None,
+    ):
+        if not logger:
+            logger = CliLogger("rod.libs.py.yc.bucket.BucketObject")
+        self.logger = logger
+
+        settings = YcSettings()
+        if token:
+            self.token = token
+        else:
+            self.token = settings.token
+
+        if not self.token:
+            raise AuthError("no auth methods found")
+
+        self.bucket = bucket
+        self.key = key
+        self.url = f"https://storage.yandexcloud.net/{self.bucket}/{self.key}"
+
+    @property
+    def data(self) -> bytes | None:
+        """Return object bytes, or None when the object does not exist."""
+        if not self:
+            return None
+
+        response = requests.get(
+            self.url,
+            headers={"Authorization": f"Bearer {self.token}"},
+            timeout=30,
+        )
+
+        response.raise_for_status()
+        return response.content
+
+    def create(self, data: bytes, content_type: str) -> None:
+        """Create this object when it does not already exist."""
+        if self:
+            self.logger.info(f"create: BucketObject {self.url} already exists")
+            return
+
+        response = requests.put(
+            self.url,
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Content-Type": content_type,
+            },
+            data=data,
+            timeout=30,
+        )
+        response.raise_for_status()
+        self.logger.info(f"create: BucketObject {self.url} success!!!")
+
+    def delete(self) -> None:
+        """Delete this object when it exists."""
+        if not self:
+            self.logger.info(f"delete: BucketObject {self.url} does not exists")
+            return
+
+        response = requests.delete(
+            self.url,
+            headers={"Authorization": f"Bearer {self.token}"},
+            timeout=30,
+        )
+
+        if response.status_code in (200, 202, 204):
+            self.logger.info(f"delete: BucketObject {self.url} success!!!")
+            return
+
+        response.raise_for_status()
+        self.logger.info(f"delete: BucketObject {self.url} success!!!")
+
+    def __bool__(self) -> bool:
+        """Return True when the object exists in Yandex Object Storage."""
+        response = requests.head(
+            self.url,
+            headers={"Authorization": f"Bearer {self.token}"},
+            timeout=10,
+        )
+
+        if response.status_code == 200:
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        response.raise_for_status()
+        return False
 
 
 class YcBucket:
@@ -161,6 +260,5 @@ class YcBucket:
         )
         self.sdk.wait_operation_and_get_result(operation)
         self.logger.info(
-            f"granted storage.admin on yc s3 tf state bucket {self.name} "
-            f"to {subject}."
+            f"granted storage.admin on yc s3 tf state bucket {self.name} to {subject.id}."
         )

--- a/rod/libs/py/yc/client.py
+++ b/rod/libs/py/yc/client.py
@@ -1,6 +1,4 @@
 import os
-from dataclasses import dataclass
-from typing import Optional
 
 import requests
 from yandexcloud import SDK
@@ -12,18 +10,23 @@ class AuthError(Exception):
     pass
 
 
-@dataclass
 class YcSettings:
     """Authentication settings discovered from the local environment."""
 
-    token: Optional[str] = None
+    @property
+    def token(self) -> str | None:
+        """Return an IAM token from YC_TOKEN or instance metadata."""
+        token = os.getenv("YC_TOKEN", None)
+        if token:
+            return token
 
-    def __post_init__(self):
-        if self.token is None:
-            self.token = os.getenv("YC_TOKEN")
+        if self.metadata_available():
+            return self.metadata_token
+
+        return None
 
     @property
-    def metadata(self):
+    def metadata(self) -> str:
         """Metadata endpoint used to request instance service account tokens."""
         m_address = os.getenv("YC_METADATA_ADDR", "169.254.169.254")
         return f"http://{m_address}/computeMetadata/v1/instance/service-accounts/default/token"
@@ -42,13 +45,24 @@ class YcSettings:
         except requests.RequestException:
             return False
 
+    @property
+    def metadata_token(self) -> str:
+        """Fetch an IAM token from the instance metadata endpoint."""
+        response = requests.get(
+            self.metadata,
+            headers={"Metadata-Flavor": "Google"},
+            timeout=5,
+        )
+        response.raise_for_status()
+        return response.json()["access_token"]
+
 
 def sdk_get(token: str = None) -> SDK:
     """Create a Yandex Cloud SDK with the first available auth method.
 
     Authentication is selected in this order: explicit IAM token, ``YC_TOKEN``
-    from the environment, then the default instance service account exposed
-    through the metadata endpoint.
+    from the environment, then an IAM token fetched from the default instance
+    service account metadata endpoint.
 
     Args:
         token: Optional IAM token that takes precedence over environment auth.
@@ -62,9 +76,8 @@ def sdk_get(token: str = None) -> SDK:
     settings = YcSettings()
     if token:
         return SDK(iam_token=token)
-    if settings.token:
-        return SDK(iam_token=settings.token)
-    if settings.metadata_available():
-        return SDK()
+    settings_token = settings.token
+    if settings_token:
+        return SDK(iam_token=settings_token)
 
     raise AuthError("no auth methods found")

--- a/rod/libs/py/yc/sa.py
+++ b/rod/libs/py/yc/sa.py
@@ -35,8 +35,7 @@ class YcServiceAccount:
         logger: BaseLogger = None,
         create_if_missing: bool = True,
     ):
-        if not logger:
-            logger = CliLogger("rod.libs.py.yc.sa.ServiceAccount")
+        logger = logger or CliLogger("rod.libs.py.yc.sa.ServiceAccount")
 
         self.sdk = sdk_get(token)
         self.folder_id = folder_id

--- a/rod/libs/py/yc/tests.py
+++ b/rod/libs/py/yc/tests.py
@@ -1,7 +1,7 @@
 import os
 import unittest
 from types import SimpleNamespace
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, PropertyMock, call, patch
 
 import grpc
 from google.protobuf.wrappers_pb2 import Int64Value, StringValue
@@ -16,6 +16,7 @@ from rod.libs.py.yc.bucket import (
     CreateBucketRequest,
     GetBucketRequest,
     YcBucket,
+    YcBucketObject,
     YcBucketConfigs,
 )
 from rod.libs.py.yc.client import AuthError, YcSettings, sdk_get
@@ -63,21 +64,27 @@ class TestSdkGet(unittest.TestCase):
         mock_sdk_cls.assert_called_once_with(iam_token="env-token")
 
     @patch.dict(os.environ, {}, clear=True)
+    @patch(
+        "rod.libs.py.yc.client.YcSettings.metadata_token",
+        new_callable=PropertyMock,
+    )
     @patch("rod.libs.py.yc.client.YcSettings.metadata_available")
     @patch("rod.libs.py.yc.client.SDK")
     def test_uses_metadata_when_no_token_is_available(
         self,
         mock_sdk_cls,
         mock_metadata_available,
+        mock_metadata_token,
     ):
         mock_metadata_available.return_value = True
+        mock_metadata_token.return_value = "metadata-token"
         sdk = MagicMock()
         mock_sdk_cls.return_value = sdk
 
         result = sdk_get()
 
         self.assertIs(result, sdk)
-        mock_sdk_cls.assert_called_once_with()
+        mock_sdk_cls.assert_called_once_with(iam_token="metadata-token")
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("rod.libs.py.yc.client.YcSettings.metadata_available", return_value=False)
@@ -107,12 +114,31 @@ class TestYcSettings(unittest.TestCase):
         )
 
     @patch("rod.libs.py.yc.client.requests.get")
+    def test_metadata_token_fetches_access_token(self, mock_get):
+        response = MagicMock()
+        response.json.return_value = {"access_token": "metadata-token"}
+        mock_get.return_value = response
+
+        self.assertEqual(YcSettings().metadata_token, "metadata-token")
+
+        mock_get.assert_called_once_with(
+            YcSettings().metadata,
+            headers={"Metadata-Flavor": "Google"},
+            timeout=5,
+        )
+        response.raise_for_status.assert_called_once()
+
+    @patch("rod.libs.py.yc.client.requests.get")
     def test_metadata_available_returns_false_for_request_errors(self, mock_get):
         import requests
 
         mock_get.side_effect = requests.RequestException
 
         self.assertFalse(YcSettings().metadata_available())
+
+    @patch.dict(os.environ, {"YC_TOKEN": "env-token"}, clear=True)
+    def test_token_uses_environment_before_metadata(self):
+        self.assertEqual(YcSettings().token, "env-token")
 
 
 class TestServiceAccount(unittest.TestCase):
@@ -265,6 +291,144 @@ class TestServiceAccount(unittest.TestCase):
         self.assertIsInstance(create_request, CreateAccessKeyRequest)
         self.assertEqual(create_request.service_account_id, sa_id)
         self.assertEqual(create_request.description, description)
+
+
+class TestBucketObject(unittest.TestCase):
+    def test_uses_explicit_token(self):
+        logger = MagicMock()
+
+        bucket_object = YcBucketObject(
+            "bucket",
+            "path/to/state.tfstate",
+            token="iam-token",
+            logger=logger,
+        )
+
+        self.assertEqual(bucket_object.bucket, "bucket")
+        self.assertEqual(bucket_object.key, "path/to/state.tfstate")
+        self.assertEqual(bucket_object.token, "iam-token")
+        self.assertEqual(
+            bucket_object.url,
+            "https://storage.yandexcloud.net/bucket/path/to/state.tfstate",
+        )
+        self.assertIs(bucket_object.logger, logger)
+
+    @patch("rod.libs.py.yc.bucket.YcSettings")
+    def test_raises_when_no_token_is_available(self, mock_settings_cls):
+        mock_settings_cls.return_value = SimpleNamespace(token=None)
+
+        with self.assertRaises(AuthError):
+            YcBucketObject("bucket", "key")
+
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_bool_returns_true_when_object_exists(self, mock_head):
+        mock_head.return_value = SimpleNamespace(status_code=200)
+
+        self.assertTrue(YcBucketObject("bucket", "key", token="iam-token"))
+
+        mock_head.assert_called_once_with(
+            "https://storage.yandexcloud.net/bucket/key",
+            headers={"Authorization": "Bearer iam-token"},
+            timeout=10,
+        )
+
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_bool_returns_false_when_object_is_missing(self, mock_head):
+        mock_head.return_value = SimpleNamespace(status_code=404)
+
+        self.assertFalse(YcBucketObject("bucket", "key", token="iam-token"))
+
+    @patch("rod.libs.py.yc.bucket.requests.get")
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_data_returns_content_when_object_exists(self, mock_head, mock_get):
+        mock_head.return_value = SimpleNamespace(status_code=200)
+        response = MagicMock()
+        response.content = b"state"
+        mock_get.return_value = response
+
+        data = YcBucketObject("bucket", "key", token="iam-token").data
+
+        self.assertEqual(data, b"state")
+        mock_get.assert_called_once_with(
+            "https://storage.yandexcloud.net/bucket/key",
+            headers={"Authorization": "Bearer iam-token"},
+            timeout=30,
+        )
+        response.raise_for_status.assert_called_once()
+
+    @patch("rod.libs.py.yc.bucket.requests.get")
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_data_returns_none_when_object_is_missing(self, mock_head, mock_get):
+        mock_head.return_value = SimpleNamespace(status_code=404)
+
+        data = YcBucketObject("bucket", "key", token="iam-token").data
+
+        self.assertIsNone(data)
+        mock_get.assert_not_called()
+
+    @patch("rod.libs.py.yc.bucket.requests.put")
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_create_puts_object_when_missing(self, mock_head, mock_put):
+        mock_head.return_value = SimpleNamespace(status_code=404)
+        response = MagicMock()
+        mock_put.return_value = response
+
+        YcBucketObject("bucket", "key", token="iam-token", logger=MagicMock()).create(
+            b"state",
+            "application/json",
+        )
+
+        mock_put.assert_called_once_with(
+            "https://storage.yandexcloud.net/bucket/key",
+            headers={
+                "Authorization": "Bearer iam-token",
+                "Content-Type": "application/json",
+            },
+            data=b"state",
+            timeout=30,
+        )
+        response.raise_for_status.assert_called_once()
+
+    @patch("rod.libs.py.yc.bucket.requests.put")
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_create_skips_existing_object(self, mock_head, mock_put):
+        logger = MagicMock()
+        mock_head.return_value = SimpleNamespace(status_code=200)
+
+        YcBucketObject("bucket", "key", token="iam-token", logger=logger).create(
+            b"state",
+            "application/json",
+        )
+
+        mock_put.assert_not_called()
+        logger.info.assert_called_once()
+
+    @patch("rod.libs.py.yc.bucket.requests.delete")
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_delete_deletes_existing_object(self, mock_head, mock_delete):
+        mock_head.return_value = SimpleNamespace(status_code=200)
+        response = MagicMock(status_code=204)
+        mock_delete.return_value = response
+
+        YcBucketObject("bucket", "key", token="iam-token", logger=MagicMock()).delete()
+
+        mock_delete.assert_called_once_with(
+            "https://storage.yandexcloud.net/bucket/key",
+            headers={"Authorization": "Bearer iam-token"},
+            timeout=30,
+        )
+        response.raise_for_status.assert_not_called()
+
+    @patch("rod.libs.py.yc.bucket.requests.delete")
+    @patch("rod.libs.py.yc.bucket.requests.head")
+    def test_delete_skips_missing_object(self, mock_head, mock_delete):
+        logger = MagicMock()
+        mock_head.return_value = SimpleNamespace(status_code=404)
+
+        YcBucketObject("bucket", "key", token="iam-token", logger=logger).delete()
+
+        mock_delete.assert_not_called()
+        logger.info.assert_called_once()
 
 
 class TestBucket(unittest.TestCase):

--- a/rod/scripts/init/tf/state/README.md
+++ b/rod/scripts/init/tf/state/README.md
@@ -13,3 +13,9 @@ For Google Cloud Platform, the Terraform state is stored in a **Google Cloud Sto
 
 These settings help ensure durability, traceability, and security of the Terraform state files.
 
+## Yandex Object Storage Notes
+
+When `AWS_ENDPOINT_URL_S3` points to Yandex Object Storage, S3 Terraform
+backends are created in Yandex Cloud. The setup grants the Terraform state
+service account access to the bucket and initializes the secrets state object
+from the backend key template.

--- a/rod/scripts/init/tf/state/create.py
+++ b/rod/scripts/init/tf/state/create.py
@@ -1,14 +1,20 @@
 from rod.libs.py.tf.state import create_gcs_tf_state
 from rod.libs.py.tf.state import create_yc_s3_tf_state
 from rod.libs.py.tf.tfvars import formatted_tfvars
-from rod.libs.py.settings import YcSettings
+from rod.libs.py.settings import AWSSettings, YcSettings
 from rod.libs.py.yc.sa import YcServiceAccount
+from types import SimpleNamespace
 import sys
 
 
 def create_state() -> None:
-    """Create Terraform state backends for all configured environments."""
+    """Create Terraform state backends for all configured environments.
+
+    For Yandex Object Storage backends, also initialize the secrets state object
+    derived from the configured backend key template.
+    """
     tfvars = formatted_tfvars()
+    aws_settings = AWSSettings()
     int_env = next(
         env_obj
         for env_name, env_obj in tfvars.envs.items()
@@ -23,8 +29,15 @@ def create_state() -> None:
             )
             if not created:
                 sys.exit(1)
-        elif env_obj.cloud.name == "yc" and env_obj.tf_backend.type == "s3":
+        elif (
+            aws_settings.s3_endpoint == "https://storage.yandexcloud.net"
+            and env_obj.tf_backend.type == "s3"
+        ):
             yc_settings = YcSettings()
+            tf_backend = SimpleNamespace(state_name="secrets")
+            secrets_state = env_obj.tf_backend.configs["key"].format(
+                tf_backend=tf_backend
+            )
             service_account = YcServiceAccount(
                 int_env.cloud.folder_id,
                 yc_settings.tf_state_sa,
@@ -33,6 +46,7 @@ def create_state() -> None:
                 env_obj.cloud.folder_id,
                 env_obj.tf_backend.configs["bucket"],
                 service_account.id,
+                secrets_state,
             )
             if not created:
                 sys.exit(1)

--- a/rod/scripts/init/tf/state/tests.py
+++ b/rod/scripts/init/tf/state/tests.py
@@ -22,7 +22,13 @@ cloud = Cloud(
     buckets={"multi_regional": "false"},
 )
 
-tf_backend = TfBackend(type="<replace-me>", configs={"bucket": "my-tf-state-bucket"})
+tf_backend = TfBackend(
+    type="<replace-me>",
+    configs={
+        "bucket": "my-tf-state-bucket",
+        "key": "{tf_backend.state_name}.tfstate",
+    },
+)
 
 
 class TestCreateState(unittest.TestCase):
@@ -60,10 +66,12 @@ class TestCreateState(unittest.TestCase):
     @patch("rod.scripts.init.tf.state.create.create_yc_s3_tf_state")
     @patch("rod.scripts.init.tf.state.create.YcServiceAccount")
     @patch("rod.scripts.init.tf.state.create.YcSettings")
+    @patch("rod.scripts.init.tf.state.create.AWSSettings")
     @patch("rod.scripts.init.tf.state.create.formatted_tfvars")
     def test_creates_yc_s3_state_for_yc_s3_backend(
         self,
         mock_formatted_tfvars,
+        mock_aws_settings_cls,
         mock_yc_settings_cls,
         mock_yc_service_account_cls,
         mock_create_yc_s3_tf_state,
@@ -83,6 +91,9 @@ class TestCreateState(unittest.TestCase):
             cloud=cloud_yc,
         )
         mock_formatted_tfvars.return_value = SimpleNamespace(envs={"dev": env_obj})
+        mock_aws_settings_cls.return_value = SimpleNamespace(
+            s3_endpoint="https://storage.yandexcloud.net",
+        )
         mock_yc_settings_cls.return_value = SimpleNamespace(
             token="iam-token",
             tf_state_sa="tf-state-sa",
@@ -102,15 +113,18 @@ class TestCreateState(unittest.TestCase):
             "folder-id",
             "my-tf-state-bucket",
             "service-account-id",
+            "secrets.tfstate",
         )
 
     @patch("rod.scripts.init.tf.state.create.create_yc_s3_tf_state")
     @patch("rod.scripts.init.tf.state.create.YcServiceAccount")
     @patch("rod.scripts.init.tf.state.create.YcSettings")
+    @patch("rod.scripts.init.tf.state.create.AWSSettings")
     @patch("rod.scripts.init.tf.state.create.formatted_tfvars")
     def test_exits_when_yc_s3_state_creation_fails(
         self,
         mock_formatted_tfvars,
+        mock_aws_settings_cls,
         mock_yc_settings_cls,
         mock_yc_service_account_cls,
         mock_create_yc_s3_tf_state,
@@ -128,6 +142,9 @@ class TestCreateState(unittest.TestCase):
             cloud=cloud_yc,
         )
         mock_formatted_tfvars.return_value = SimpleNamespace(envs={"dev": env_obj})
+        mock_aws_settings_cls.return_value = SimpleNamespace(
+            s3_endpoint="https://storage.yandexcloud.net",
+        )
         mock_yc_settings_cls.return_value = SimpleNamespace(tf_state_sa="tf-state-sa")
         mock_yc_service_account_cls.return_value = SimpleNamespace(
             id="service-account-id"
@@ -142,7 +159,40 @@ class TestCreateState(unittest.TestCase):
             "folder-id",
             "my-tf-state-bucket",
             "service-account-id",
+            "secrets.tfstate",
         )
+
+    @patch("rod.scripts.init.tf.state.create.create_yc_s3_tf_state")
+    @patch("rod.scripts.init.tf.state.create.AWSSettings")
+    @patch("rod.scripts.init.tf.state.create.formatted_tfvars")
+    def test_raises_for_s3_backend_without_yandex_endpoint(
+        self,
+        mock_formatted_tfvars,
+        mock_aws_settings_cls,
+        mock_create_yc_s3_tf_state,
+    ):
+        cloud_yc = cloud.model_copy(deep=True)
+        tf_backend_ycs3 = tf_backend.model_copy(deep=True)
+
+        cloud_yc.name = "yc"
+        cloud_yc.folder_id = "folder-id"
+        tf_backend_ycs3.type = "s3"
+
+        env_obj = SimpleNamespace(
+            type="internal",
+            tf_backend=tf_backend_ycs3,
+            cloud=cloud_yc,
+        )
+        mock_formatted_tfvars.return_value = SimpleNamespace(envs={"dev": env_obj})
+        mock_aws_settings_cls.return_value = SimpleNamespace(
+            s3_endpoint="https://example.invalid",
+        )
+
+        with self.assertRaises(NotImplementedError) as ctx:
+            create_state()
+
+        self.assertIn("No tf_state scripts for s3", str(ctx.exception))
+        mock_create_yc_s3_tf_state.assert_not_called()
 
     @patch("rod.scripts.init.tf.state.create.create_gcs_tf_state")
     @patch("rod.scripts.init.tf.state.create.formatted_tfvars")


### PR DESCRIPTION
`@svetoch_bazel_lib//rod/scripts/init/tf/state`  create empty `secrets` state files in yc s3 backend.

When why issue `bazel run @svetoch_bazel_lib//rod/scripts/init` command the flow is as follows

1. remove `.git` folder
2. init terraform 
   1. cloud specific terraform perparation steps (for example api enable)
   2. Check tfvars and copy `product` folder to each product env
   3. Create tf state
   4. terraform apply
   5. terraform import secrets
   6.  Remove product folder
3. push images
   1. Prepare credential helpers
   2. push images
 
So on step 2.v we are working with `terraform state` command. This means that state file must be there in order for any `terraform state` commands to work. Somehow when backend is `gcs` `terraform init` creates empty terraform states if no files are present but `s3` does not create anything until `apply` is done. So with s3 backend on step 2.v we get an error and to mitigate this we need to create empty tf state files before we run `terraform import secrets` 